### PR TITLE
FIX table in QMX_Output_Html_VarDumps::output()

### DIFF
--- a/output/var_dumps.php
+++ b/output/var_dumps.php
@@ -27,13 +27,30 @@ class QMX_Output_Html_VarDumps extends QM_Output_Html {
         		echo '<thead><tr><th>Var Dump: ' . $array['label'] . '</th></tr></thead>';
                 echo '<tbody><tr><td>';
 
-    			QM_Output_Html::output_inner( $array['var'] );
+                $var = $this->prepare_output_inner( $array['var'] );
+    			QM_Output_Html::output_inner( $var );
 
                 echo '</td></tr></tbody>';
                 echo '</table>';
                 echo '</div>';
             }
 
+	}
+
+	public function prepare_output_inner( $var ){
+		if( ! is_object( $var ) || ! is_array( $var ) ){
+			if( is_string( $var) ){
+				$var = [ 'string' => $var ];
+			} elseif ( is_int( $var ) ){
+				$var = [ 'integer' => $var ];
+			} elseif ( is_float( $var ) ){
+				$var = [ 'float' => $var ];
+			} elseif ( is_bool( $var ) ){
+				$var = [ 'boolean' => $var ];
+			}
+		}
+
+		return $var;
 	}
 
     public function admin_menu( array $menu ) {

--- a/output/var_dumps.php
+++ b/output/var_dumps.php
@@ -18,15 +18,13 @@ class QMX_Output_Html_VarDumps extends QM_Output_Html {
 
 		$data = $this->collector->get_data();
 
-		echo '<span id="' . esc_attr( $this->collector->id() ) . '"></span>';
-
         if ( array_key_exists( 'vardumps', $data ) && is_array( $data['vardumps'] ) && count( $data['vardumps'] ) )
     		foreach ( $data['vardumps'] as $id => $array ) {
 
-                echo '<div id="' . esc_attr( $this->collector->id() . '-' . $id ) . '" class="qm">';
+                echo '<div id="' . esc_attr( $this->collector->id() ) . '" class="qm">';
 
                 echo '<table cellspacing="0">';
-        		echo '<thead><tr><td>Var Dump: ' . $array['label'] . '</td></tr></thead>';
+        		echo '<thead><tr><th>Var Dump: ' . $array['label'] . '</th></tr></thead>';
                 echo '<tbody><tr><td>';
 
     			QM_Output_Html::output_inner( $array['var'] );


### PR DESCRIPTION
The table was not displayed because of the incorrect naming of the ID of the DIV container and SPAN tag is superfluous.