### PR TITLE
Fixed two bugs

### DIFF
--- a/collectors/image_sizes.php
+++ b/collectors/image_sizes.php
@@ -97,6 +97,7 @@ class QMX_Collector_Image_Sizes extends QMX_Collector {
 		$counts = array( 'dimensions' => array(), 'ratios' => array() );
 
 		foreach ( $this->data['sizes'] as $size ) {
+			$size['crop'] = is_array( $size ['crop'] ) ? implode( '_', $size['crop'] ) : $size['crop'];
 			$key = $size['width'] . ':' . $size['height'] . ' - ' . $size['crop'];
 			array_key_exists( $key, $counts['dimensions'] )
 				? $counts['dimensions'][$key]++

--- a/output/html/files.php
+++ b/output/html/files.php
@@ -157,7 +157,7 @@ class QMX_Output_Html_Files extends QMX_Output_Html {
 
 	private function human_file_size( $bytes ) {
 		$filesize_units = 'BKMGTP';
-		$factor = floor( ( strlen( $bytes ) - 1 ) / 3 );
+		$factor = intval( floor( ( strlen( $bytes ) - 1 ) / 3 ) );
 		return sprintf( "%.2f", $bytes / pow( 1024, $factor ) ) . @$filesize_units[$factor];
 	}
 


### PR DESCRIPTION
In the `output/html/files.php:160`, `floor()` result value (float) is used for the string offset, therefore I added `intval()` to convert `float` to `int`.

In the `collectors/image_sizes.php:101` and further, `$size['crop']` is used as string. But sometimes it can be an array, `[ 'center', 'center' ]` for example. So I added the conditional `implode()` statement to convert it to string.