### PR TITLE
Establish testable structure

### DIFF
--- a/acf/qmx-acf-collector.php
+++ b/acf/qmx-acf-collector.php
@@ -20,7 +20,7 @@ class QMX_Collector_ACF extends QM_DataCollector {
 	}
 
 	public function get_storage(): QM_Data {
-		require_once 'qmx-acf-data.php'
+		require_once 'qmx-acf-data.php';
 		return new QMX_Data_ACF();
 	}
 

--- a/acf/qmx-acf-collector.php
+++ b/acf/qmx-acf-collector.php
@@ -1,259 +1,224 @@
 <?php
-/**
- * Plugin Name: QMX: ACF Collector
- * Plugin URI: https://github.com/crstauf/query-monitor-extend/tree/master/acf
- * Description: Query Monitor collector for Advanced Custom Fields.
- * Version: 1.0.1
- * Author: Caleb Stauffer
- * Author URI: https://develop.calebstauffer.com
- * Update URI: false
- */
 
 defined( 'WPINC' ) || die();
 
-defined( 'QMX_DISABLED' ) || define( 'QMX_DISABLED', false );
-defined( 'QMX_TESTED_WITH_QM' ) || define( 'QMX_TESTED_WITH_QM', '3.13.0' );
+class QMX_Collector_ACF extends QM_DataCollector {
 
-add_action( 'plugin_loaded', 'load_qmx_acf_collector' );
+	public $id = 'acf';
 
-function load_qmx_acf_collector( string $file ) {
+	function __construct() {
+		parent::__construct();
 
-	if ( 'query-monitor/query-monitor.php' !== plugin_basename( $file ) ) {
-		return;
+		add_action( 'acf/init', array( $this, 'action__acf_init' ) );
+
+		add_filter( 'acf/settings/load_json', array( $this, 'filter__acf_settings_load_json' ), 99999 );
+		add_filter( 'acf/pre_load_value', array( $this, 'filter__acf_pre_load_value' ), 10, 3);
+		add_filter( 'acf/load_field_groups', array( $this, 'filter__acf_load_field_groups' ) );
+
+		// Set default value. Filter applied in output.
+		$this->data->local_json['save'] = get_stylesheet_directory() . '/acf-json';
 	}
 
-	remove_action( 'plugin_loaded', __FUNCTION__ );
-
-	if ( ! class_exists( 'QueryMonitor' ) ) {
-		return;
+	public function get_storage(): QM_Data {
+		require_once 'qmx-acf-data.php'
+		return new QMX_Data_ACF();
 	}
 
-	if ( defined( 'QM_DISABLED' ) && constant( 'QM_DISABLED' ) ) {
-		return;
+	public function process() {}
+
+	public static function get_fields_group( $parent ) {
+		if ( is_null( $parent ) ) {
+			return null;
+		}
+
+		$group = acf_get_field_group( $parent );
+
+		if ( false === $group ) {
+			$field = acf_get_field( $parent );
+			return static::get_fields_group( $field['parent'] );
+		}
+
+		return $group;
 	}
 
-	if ( constant( 'QMX_DISABLED' ) ) {
-		return;
+	public function action__acf_init() : void {
+		$files = acf_get_local_json_files();
+		$groups = array();
+
+		foreach ( $files as $group_key => $filepath ) {
+			$groups[ $group_key ] = acf_get_field_group( $group_key );
+		}
+
+		$this->data->local_json['groups'] = $groups;
 	}
 
-	class QMX_Collector_ACF extends QM_DataCollector {
-
-		public $id = 'acf';
-
-		function __construct() {
-			parent::__construct();
-
-			add_action( 'acf/init', array( $this, 'action__acf_init' ) );
-
-			add_filter( 'acf/settings/load_json', array( $this, 'filter__acf_settings_load_json' ), 99999 );
-			add_filter( 'acf/pre_load_value', array( $this, 'filter__acf_pre_load_value' ), 10, 3);
-			add_filter( 'acf/load_field_groups', array( $this, 'filter__acf_load_field_groups' ) );
-
-			// Set default value. Filter applied in output.
-			$this->data->local_json['save'] = get_stylesheet_directory() . '/acf-json';
-		}
-
-		public function get_storage(): QM_Data {
-			do_action( 'qmx/load_data/acf' );
-			return new QMX_Data_ACF();
-		}
-
-		public function process() {}
-
-		public static function get_fields_group( $parent ) {
-			if ( is_null( $parent ) ) {
-				return null;
-			}
-
-			$group = acf_get_field_group( $parent );
-
-			if ( false === $group ) {
-				$field = acf_get_field( $parent );
-				return static::get_fields_group( $field['parent'] );
-			}
-
-			return $group;
-		}
-
-		public function action__acf_init() : void {
-			$files = acf_get_local_json_files();
-			$groups = array();
-
-			foreach ( $files as $group_key => $filepath ) {
-				$groups[ $group_key ] = acf_get_field_group( $group_key );
-			}
-
-			$this->data->local_json['groups'] = $groups;
-		}
-
-		public function filter__acf_settings_load_json( $paths ) {
-			if ( did_action( 'qm/cease' ) ) {
-				return $paths;
-			}
-
-			$this->data->local_json['load'] = $paths;
-
+	public function filter__acf_settings_load_json( $paths ) {
+		if ( did_action( 'qm/cease' ) ) {
 			return $paths;
 		}
 
-		protected static function get_start_trace_functions() {
-			$functions = null;
+		$this->data->local_json['load'] = $paths;
 
-			if ( ! is_null( $functions ) ) {
-				return $functions;
-			}
+		return $paths;
+	}
 
-			$functions = apply_filters( 'qmx/collector/acf/start_trace_functions', array(
-				'get_field',
-				'get_field_object',
-				'have_rows',
-			) );
+	protected static function get_start_trace_functions() {
+		$functions = null;
 
+		if ( ! is_null( $functions ) ) {
 			return $functions;
 		}
 
-		public function filter__acf_pre_load_value( $short_circuit, $post_id, $field ) {
-			if ( did_action( 'qm/cease' ) ) {
-				return $short_circuit;
-			}
+		$functions = apply_filters( 'qmx/collector/acf/start_trace_functions', array(
+			'get_field',
+			'get_field_object',
+			'have_rows',
+		) );
 
-			$full_stack_trace = apply_filters( 'qmx/collector/acf/full_stack_trace', is_admin(), $post_id, $field );
-			$trace = new QM_Backtrace( array( 'ignore_current_filter' => ! $full_stack_trace ) );
+		return $functions;
+	}
 
-			if ( false === $full_stack_trace ) {
-				foreach ($trace->get_trace() as $frame) {
-					if (
-						in_array( $frame['function'], static::get_start_trace_functions() )
-						&& false === stripos( $frame['file'], ACF_PATH )
-					) {
-						break;
-					}
-
-					if ( ! empty( $trace->get_trace()[1] ) ) {
-						$trace->ignore( 1 );
-					}
-				}
-			}
-
-			$row = array(
-				'field'     => $field,
-				'post_id'   => acf_get_valid_post_id( $post_id ),
-				'trace'     => $trace,
-				'exists'    => ! empty( $field['key'] ),
-				'caller'    => $trace->get_trace()[0],
-				'group'     => null,
-				'hash'      => null,
-				'duplicate' => false,
-			);
-
-			if ( ! empty( $field['key'] ) ) {
-				$row['group'] = static::get_fields_group( $field['parent'] );
-			}
-
-			$hash = md5( json_encode( $row ) );
-			$row['hash'] = $hash;
-
-			if ( array_key_exists( $hash, $this->data->counts ) ) {
-				$this->data->counts[ $hash ]++;
-
-				if ( apply_filters( 'qmx/collector/acf/hide_duplicates', false ) ) {
-					return $short_circuit;
-				}
-
-				$row['duplicate'] = true;
-			}
-
-			if ( ! empty( $field['key'] ) ) {
-				$this->data->field_keys[ $field['key'] ] = $field['name'];
-			} else {
-				$this->data->field_keys[ $field['name'] ] = $field['name'];
-			}
-
-			if ( ! empty( $row['group'] ) ) {
-				$this->data->field_groups[ $row['group']['key'] ] = $row['group']['title'];
-			}
-
-			$this->data->post_ids[ ( string ) $post_id ] = $post_id;
-			$this->data->callers[ $row['caller']['function'] . '()' ] = 1;
-			$this->data->counts[ $hash ] = 1;
-
-			$this->data->fields[] = $row;
-
+	public function filter__acf_pre_load_value( $short_circuit, $post_id, $field ) {
+		if ( did_action( 'qm/cease' ) ) {
 			return $short_circuit;
 		}
 
-		public function filter__acf_load_field_groups( $field_groups ) {
-			static $processed = array();
+		$full_stack_trace = apply_filters( 'qmx/collector/acf/full_stack_trace', is_admin(), $post_id, $field );
+		$trace = new QM_Backtrace( array( 'ignore_current_filter' => ! $full_stack_trace ) );
 
-			if ( empty( $field_groups ) ) {
-				return $field_groups;
-			}
-
-			$hash = wp_hash( json_encode( $field_groups ) );
-
-			if ( in_array( $hash, $processed ) ) {
-				return;
-			}
-
-			$processed[] = $hash;
-
-			foreach ( $field_groups as $field_group ) {
-				$key = wp_hash( json_encode( $field_group ) );
-
-				if ( array_key_exists( $key, $this->data->loaded_field_groups ) ) {
-					continue;
+		if ( false === $full_stack_trace ) {
+			foreach ($trace->get_trace() as $frame) {
+				if (
+					in_array( $frame['function'], static::get_start_trace_functions() )
+					&& false === stripos( $frame['file'], ACF_PATH )
+				) {
+					break;
 				}
 
-				$this->data->loaded_field_groups[ $key ] = array(
-					'id'    => $field_group['ID'],
-					'group' => $field_group['key'],
-					'title' => $field_group['title'],
-					'rules' => $field_group['location'],
-				);
+				if ( ! empty( $trace->get_trace()[1] ) ) {
+					$trace->ignore( 1 );
+				}
+			}
+		}
+
+		$row = array(
+			'field'     => $field,
+			'post_id'   => acf_get_valid_post_id( $post_id ),
+			'trace'     => $trace,
+			'exists'    => ! empty( $field['key'] ),
+			'caller'    => $trace->get_trace()[0],
+			'group'     => null,
+			'hash'      => null,
+			'duplicate' => false,
+		);
+
+		if ( ! empty( $field['key'] ) ) {
+			$row['group'] = static::get_fields_group( $field['parent'] );
+		}
+
+		$hash = md5( json_encode( $row ) );
+		$row['hash'] = $hash;
+
+		if ( array_key_exists( $hash, $this->data->counts ) ) {
+			$this->data->counts[ $hash ]++;
+
+			if ( apply_filters( 'qmx/collector/acf/hide_duplicates', false ) ) {
+				return $short_circuit;
 			}
 
+			$row['duplicate'] = true;
+		}
+
+		if ( ! empty( $field['key'] ) ) {
+			$this->data->field_keys[ $field['key'] ] = $field['name'];
+		} else {
+			$this->data->field_keys[ $field['name'] ] = $field['name'];
+		}
+
+		if ( ! empty( $row['group'] ) ) {
+			$this->data->field_groups[ $row['group']['key'] ] = $row['group']['title'];
+		}
+
+		$this->data->post_ids[ ( string ) $post_id ] = $post_id;
+		$this->data->callers[ $row['caller']['function'] . '()' ] = 1;
+		$this->data->counts[ $hash ] = 1;
+
+		$this->data->fields[] = $row;
+
+		return $short_circuit;
+	}
+
+	public function filter__acf_load_field_groups( $field_groups ) {
+		static $processed = array();
+
+		if ( empty( $field_groups ) ) {
 			return $field_groups;
 		}
 
-		public function get_concerned_actions() {
-			$actions = array(
-				'acf/init',
-			);
+		$hash = wp_hash( json_encode( $field_groups ) );
 
-			return $actions;
+		if ( in_array( $hash, $processed ) ) {
+			return;
 		}
 
-		public function get_concerned_filters() {
-			$filters = array(
-				'acf/is_field_group_key',
-				'acf/is_field_key',
-				'acf/load_field_group',
-				'acf/pre_load_post_id',
-				'acf/validate_post_id',
-				'acf/pre_load_value',
-				'acf/load_value',
-				'acf/settings/load_json',
-			);
+		$processed[] = $hash;
 
-			if ( is_admin() ) {
-				$filters = array_merge( $filters, array(
-					'acf/settings/save_json',
-					'acf/load_field_groups',
-				) );
+		foreach ( $field_groups as $field_group ) {
+			$key = wp_hash( json_encode( $field_group ) );
+
+			if ( array_key_exists( $key, $this->data->loaded_field_groups ) ) {
+				continue;
 			}
 
-			sort( $filters, SORT_STRING );
-
-			return $filters;
-		}
-
-		public function get_concerned_constants() {
-			return array(
-				'ACF_LITE',
+			$this->data->loaded_field_groups[ $key ] = array(
+				'id'    => $field_group['ID'],
+				'group' => $field_group['key'],
+				'title' => $field_group['title'],
+				'rules' => $field_group['location'],
 			);
 		}
 
+		return $field_groups;
 	}
 
-	QM_Collectors::add( new QMX_Collector_ACF );
+	public function get_concerned_actions() {
+		$actions = array(
+			'acf/init',
+		);
+
+		return $actions;
+	}
+
+	public function get_concerned_filters() {
+		$filters = array(
+			'acf/is_field_group_key',
+			'acf/is_field_key',
+			'acf/load_field_group',
+			'acf/pre_load_post_id',
+			'acf/validate_post_id',
+			'acf/pre_load_value',
+			'acf/load_value',
+			'acf/settings/load_json',
+		);
+
+		if ( is_admin() ) {
+			$filters = array_merge( $filters, array(
+				'acf/settings/save_json',
+				'acf/load_field_groups',
+			) );
+		}
+
+		sort( $filters, SORT_STRING );
+
+		return $filters;
+	}
+
+	public function get_concerned_constants() {
+		return array(
+			'ACF_LITE',
+		);
+	}
+
 }
+
+QM_Collectors::add( new QMX_Collector_ACF );

--- a/acf/qmx-acf-data.php
+++ b/acf/qmx-acf-data.php
@@ -1,37 +1,16 @@
 <?php
-/**
- * Plugin Name: QMX: ACF Data
- * Plugin URI: https://github.com/crstauf/query-monitor-extend/tree/master/acf
- * Description: Query Monitor data for ACF collector.
- * Version: 1.0.1
- * Author: Caleb Stauffer
- * Author URI: https://develop.calebstauffer.com
- * Update URI: false
- */
 
 defined( 'WPINC' ) || die();
 
-if ( defined( 'QM_DISABLED' ) && constant( 'QM_DISABLED' ) ) {
-	return;
+class QMX_Data_ACF extends QM_Data {
+
+	public $fields = array();
+	public $field_keys = array();
+	public $post_ids = array();
+	public $callers = array();
+	public $counts = array();
+	public $field_groups = array();
+	public $local_json = array();
+	public $loaded_field_groups = array();
+
 }
-
-if ( constant( 'QMX_DISABLED' ) ) {
-	return;
-}
-
-add_action( 'qmx/load_data/acf', static function () {
-
-	class QMX_Data_ACF extends QM_Data {
-
-		public $fields = array();
-		public $field_keys = array();
-		public $post_ids = array();
-		public $callers = array();
-		public $counts = array();
-		public $field_groups = array();
-		public $local_json = array();
-		public $loaded_field_groups = array();
-
-	}
-
-} );

--- a/acf/qmx-acf-output.php
+++ b/acf/qmx-acf-output.php
@@ -1,611 +1,553 @@
 <?php
-/**
- * Plugin Name: QMX: ACF Output
- * Plugin URI: https://github.com/crstauf/query-monitor-extend/tree/master/acf
- * Description: Query Monitor output for ACF collector.
- * Version: 1.0.1
- * Author: Caleb Stauffer
- * Author URI: https://develop.calebstauffer.com
- * Update URI: false
- */
 
 defined( 'WPINC' ) || die();
 
-add_action( 'shutdown', static function () {
+class QMX_Output_Html_ACF extends QM_Output_Html {
 
-	if ( ! class_exists( 'QMX_Collector_ACF' ) ) {
-		return;
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+
+		add_filter( 'qm/output/panel_menus', array( $this, 'panel_menu' ), 60 );
 	}
 
-	if ( ! class_exists( 'QM_Dispatcher_Html' ) || ! QM_Dispatcher_Html::user_can_view() || ! QM_Dispatcher_Html::request_supported() ) {
-		return;
+	public function name() {
+		return __( 'Advanced Custom Fields', 'query-monitor-extend' );
 	}
 
-	if ( defined( 'QM_DISABLED' ) && constant( 'QM_DISABLED' ) ) {
-		return;
-	}
+	protected static function identify_duplicates() {
+		$bool = null;
 
-	if ( constant( 'QMX_DISABLED' ) ) {
-		return;
-	}
-
-	if ( is_admin() ) {
-		if ( ! ( did_action( 'admin_init' ) || did_action( 'admin_footer' ) ) ) {
-			return;
-		}
-	} else {
-		if ( ! ( did_action( 'wp' ) || did_action( 'wp_footer' ) || did_action( 'login_init' ) || did_action( 'gp_head' ) || did_action( 'login_footer' ) || did_action( 'gp_footer' ) ) ) {
-			return;
-		}
-	}
-
-	/** Back-compat filter. Please use `qm/dispatch/html` instead */
-	if ( ! apply_filters( 'qm/process', true, is_admin_bar_showing() ) ) {
-		return;
-	}
-
-	$qm = QueryMonitor::init()->plugin_path( 'assets/query-monitor.css' );
-
-	if ( ! file_exists( $qm ) ) {
-		return;
-	}
-
-	$qm_dir = trailingslashit( dirname( dirname( $qm ) ) );
-
-	if ( ! file_exists( $qm_dir . 'output/Html.php' ) ) {
-		return;
-	}
-
-	require_once $qm_dir . 'output/Html.php';
-
-	class QMX_Output_Html_ACF extends QM_Output_Html {
-
-		public function __construct( QM_Collector $collector ) {
-			parent::__construct( $collector );
-
-			add_filter( 'qm/output/panel_menus', array( $this, 'panel_menu' ), 60 );
-		}
-
-		public function name() {
-			return __( 'Advanced Custom Fields', 'query-monitor-extend' );
-		}
-
-		protected static function identify_duplicates() {
-			$bool = null;
-
-			if ( ! is_null( $bool) ) {
-				return $bool;
-			}
-
-			$bool = apply_filters( 'qmx/output/acf/identify_duplicates', false );
-
+		if ( ! is_null( $bool) ) {
 			return $bool;
 		}
 
-		public function output() {
-			$data = $this->collector->get_data();
+		$bool = apply_filters( 'qmx/output/acf/identify_duplicates', false );
 
-			$this->output_fields_table();
-			$this->output_local_json();
-			$this->output_concerns();
+		return $bool;
+	}
 
-			if ( is_admin() ) {
-				$this->output_field_groups_table();
-			}
+	public function output() {
+		$data = $this->collector->get_data();
+
+		$this->output_fields_table();
+		$this->output_local_json();
+		$this->output_concerns();
+
+		if ( is_admin() ) {
+			$this->output_field_groups_table();
+		}
+	}
+
+	protected function output_fields_table() {
+		$data = $this->collector->get_data();
+
+		if ( empty( $data->fields ) ) {
+			$this->before_non_tabular_output();
+			echo '<div class="qm-notice"><p>No Advanced Custom Fields found.</p></div>';
+			$this->after_non_tabular_output();
+			return;
 		}
 
-		protected function output_fields_table() {
-			$data = $this->collector->get_data();
+		echo '<style>.qm-hide-acf-field, .qm-hide-acf-post, .qm-hide-acf-group, .qm-hide-acf-caller { display: none !important; }</style>';
 
-			if ( empty( $data->fields ) ) {
-				$this->before_non_tabular_output();
-				echo '<div class="qm-notice"><p>No Advanced Custom Fields found.</p></div>';
-				$this->after_non_tabular_output();
-				return;
-			}
+		natsort( $data->field_keys );
+		natsort( $data->post_ids );
+		natsort( $data->field_groups );
+		natsort( $data->callers );
 
-			echo '<style>.qm-hide-acf-field, .qm-hide-acf-post, .qm-hide-acf-group, .qm-hide-acf-caller { display: none !important; }</style>';
+		$this->before_tabular_output();
 
-			natsort( $data->field_keys );
-			natsort( $data->post_ids );
-			natsort( $data->field_groups );
-			natsort( $data->callers );
+		echo '<thead>';
 
-			$this->before_tabular_output();
+		echo '<tr>';
 
-			echo '<thead>';
+		echo '<th scope="col" class="qm-sorted-asc qm-sortable-column" role="columnheader" aria-sort="ascending">';
+		echo $this->build_sorter( '#' );
+		echo '</th>';
 
-			echo '<tr>';
+		echo '<th scope="col" class="qm-filterable-column">';
+		echo $this->build_filter(
+			'acf-field',
+			$data->field_keys,
+			__( 'Field', 'query-monitor' ),
+			array(
+				'prepend' => array(
+					'qmx-acf-no-field' => 'Missing',
+				),
+			)
+		);
+		echo '</th>';
 
-			echo '<th scope="col" class="qm-sorted-asc qm-sortable-column" role="columnheader" aria-sort="ascending">';
-			echo $this->build_sorter( '#' );
-			echo '</th>';
+		echo '<th scope="col" class="qm-filterable-column">';
+		echo $this->build_filter( 'acf-post', $data->post_ids, __( 'Post ID', 'query-monitor' ) );
+		echo '</th>';
 
-			echo '<th scope="col" class="qm-filterable-column">';
-			echo $this->build_filter(
-				'acf-field',
-				$data->field_keys,
-				__( 'Field', 'query-monitor' ),
-				array(
-					'prepend' => array(
-						'qmx-acf-no-field' => 'Missing',
-					),
-				)
+		echo '<th scope="col" class="qm-filterable-column">';
+		echo $this->build_filter( 'acf-group', $data->field_groups, __( 'Group', 'query-monitor' ) );
+		echo '</th>';
+
+		echo '<th scope="col" class="qm-filterable-column">';
+		echo $this->build_filter( 'acf-caller', array_keys( $data->callers ), __( 'Caller', 'query-monitor' ) );
+		echo '</th>';
+
+		echo '</tr>';
+
+		echo '</thead>';
+
+		echo '<tbody>';
+
+		foreach ( $data->fields as $row_num => $row ) {
+			$row_attr = array(
+				'class' => '',
 			);
-			echo '</th>';
-
-			echo '<th scope="col" class="qm-filterable-column">';
-			echo $this->build_filter( 'acf-post', $data->post_ids, __( 'Post ID', 'query-monitor' ) );
-			echo '</th>';
-
-			echo '<th scope="col" class="qm-filterable-column">';
-			echo $this->build_filter( 'acf-group', $data->field_groups, __( 'Group', 'query-monitor' ) );
-			echo '</th>';
-
-			echo '<th scope="col" class="qm-filterable-column">';
-			echo $this->build_filter( 'acf-caller', array_keys( $data->callers ), __( 'Caller', 'query-monitor' ) );
-			echo '</th>';
-
-			echo '</tr>';
-
-			echo '</thead>';
-
-			echo '<tbody>';
-
-			foreach ( $data->fields as $row_num => $row ) {
-				$row_attr = array(
-					'class' => '',
-				);
-
-				if ( ! $row['exists'] ) {
-					$row_attr['class'] .= ' qm-warn';
-				}
-
-				$row_attr['data-qm-acf-field'] = $row['field']['name'] . ' ' . $row['field']['key'];
-				$row_attr['data-qm-acf-post'] = $row['post_id'];
-				$row_attr['data-qm-acf-caller'] = $row['caller']['function'] . '()';
-				$row_attr['data-qm-acf-group'] = 'qmx-acf-no-group';
-
-				if ( empty( $row['field']['key'] ) ) {
-					$row_attr['data-qm-acf-field'] .= ' qmx-acf-no-field';
-				}
-
-				if ( ! empty( $row['group'] ) ) {
-					$row_attr['data-qm-acf-group'] = $row['group']['key'];
-				}
-
-				if (
-					! empty( $row['duplicate'] )
-					&& static::identify_duplicates()
-				) {
-					$row_attr['class'] .= ' qm-highlight';
-				}
-
-				$attr = '';
-
-				foreach ( $row_attr as $a => $v ) {
-					$attr .= ' ' . $a . '="' . esc_attr( trim( $v ) ) . '"';
-				}
-
-				echo '<tr' . $attr . '>';
-
-				# Number
-				echo '<th scope="row" class="qm-row-num qm-num">' . esc_html( $row_num + 1 ) . '</th>';
-
-				# Field name
-				echo '<td class="qm-ltr qm-has-toggle qm-nowrap">';
-				$this->output_column_field_name( $row );
-				echo '</td>';
-
-				# Post ID
-				echo '<td class="qm-ltr">' . esc_html( $row['post_id'] ) . '</td>';
-
-				# Field group
-				echo '<td class="qm-ltr">';
-				$this->output_column_field_group( $row );
-				echo '</td>';
-
-				# Caller
-				echo '<td class="qm-row-caller qm-ltr qm-has-toggle qm-nowrap">';
-				$this->output_column_caller( $row );
-				echo '</td>';
-
-				echo '</tr>';
-			}
-
-			echo '</tbody>';
-
-			echo '<tfoot>';
-			echo '<tr>';
-			printf( '<td colspan="5">Total: %d</td>', count( $data->fields ) );
-			echo '</tr>';
-			echo '</tfoot>';
-
-			echo '</table>';
-			echo '</div>';
-		}
-
-		protected function output_field_groups_table() {
-			$id = 'qm-acf-loaded_field_groups';
-			$name = 'Advanced Custom Fields: Loaded Field Groups';
-			$data = $this->collector->get_data();
-
-			printf(
-				'<div class="qm qm-concerns" id="%1$s" role="tabpanel" aria-labelledby="%1$s-caption" tabindex="-1">',
-				esc_attr( $id )
-			);
-
-			echo '<table class="qm-sortable">';
-
-			printf(
-				'<caption><h2 id="%1$s-caption">%2$s</h2></caption>',
-				esc_attr( $id ),
-				esc_html( $name )
-			);
-
-			echo '<thead>';
-
-			echo '<tr>';
-
-			echo '<th scope="col">';
-			echo esc_html__( 'Field Group', 'query-monitor-extend' );
-			echo '</th>';
-
-			echo '<th scope="col">';
-			echo esc_html__( 'Key', 'query-monitor-extend' );
-			echo '</th>';
-
-			echo '<th scope="col">';
-			echo esc_html__( 'Rules', 'query-monitor-extend' );
-			echo '</th>';
-
-			echo '</tr>';
-
-			echo '</thead>';
-
-			echo '<tbody>';
-
-			$row_num = 1;
-
-			foreach ( $data->loaded_field_groups as $row ) {
-				$class = '';
-
-				if ( 1 === $row_num % 2 ) {
-					$class = ' class="qm-odd"';
-				}
-
-				echo '<tr' . $class . '>';
-
-				# Field group name
-				echo '<td class="qm-ltr qm-nowrap">';
-				$this->output_column_field_group_title( $row );
-				echo '</td>';
-
-				# Field group key
-				echo '<td class="qm-ltr">';
-				$this->output_column_field_group_key( $row );
-				echo '</td>';
-
-				# Field group rules
-				echo '<td class="qm-ltr qm-nowrap qm-has-inner">';
-				$this->output_column_field_group_rules( $row );
-				echo '</td>';
-
-				echo '</tr>';
-			}
-
-			echo '</tbody>';
-
-			echo '<tfoot>';
-			echo '<tr>';
-			printf( '<td colspan="3">Total: %d</td>', count( $data->loaded_field_groups ) );
-			echo '</tr>';
-			echo '</tfoot>';
-
-			echo '</table>';
-			echo '</div>';
-		}
-
-		protected function output_column_field_name( array $row ) {
-			echo esc_html( $row['field']['name'] );
 
 			if ( ! $row['exists'] ) {
-				echo ' (Missing)';
-				return;
+				$row_attr['class'] .= ' qm-warn';
+			}
+
+			$row_attr['data-qm-acf-field'] = $row['field']['name'] . ' ' . $row['field']['key'];
+			$row_attr['data-qm-acf-post'] = $row['post_id'];
+			$row_attr['data-qm-acf-caller'] = $row['caller']['function'] . '()';
+			$row_attr['data-qm-acf-group'] = 'qmx-acf-no-group';
+
+			if ( empty( $row['field']['key'] ) ) {
+				$row_attr['data-qm-acf-field'] .= ' qmx-acf-no-field';
+			}
+
+			if ( ! empty( $row['group'] ) ) {
+				$row_attr['data-qm-acf-group'] = $row['group']['key'];
 			}
 
 			if (
 				! empty( $row['duplicate'] )
 				&& static::identify_duplicates()
 			) {
-				echo ' (Duplicate)';
+				$row_attr['class'] .= ' qm-highlight';
 			}
 
-			$parent = $row['field']['parent'];
+			$attr = '';
 
-			if ( ! empty( $row['group'] ) ) {
-				$parent = $row['group']['key'];
+			foreach ( $row_attr as $a => $v ) {
+				$attr .= ' ' . $a . '="' . esc_attr( trim( $v ) ) . '"';
 			}
 
-			echo self::build_toggler();
+			echo '<tr' . $attr . '>';
 
-			echo '<div class="qm-toggled qm-supplemental qm-info">';
-			echo esc_html( 'Key: ' . $row['field']['key'] );
-			echo '<br />' . esc_html( 'Parent: ' . $parent );
-			echo '</div>';
-		}
+			# Number
+			echo '<th scope="row" class="qm-row-num qm-num">' . esc_html( $row_num + 1 ) . '</th>';
 
-		protected function output_column_field_group_title( array $row ) {
-			$title = $row['title'];
+			# Field name
+			echo '<td class="qm-ltr qm-has-toggle qm-nowrap">';
+			$this->output_column_field_name( $row );
+			echo '</td>';
 
-			if ( empty( $title ) ) {
-				return;
-			}
+			# Post ID
+			echo '<td class="qm-ltr">' . esc_html( $row['post_id'] ) . '</td>';
 
-			if ( empty( $row['id'] ) || ! current_user_can( 'edit_post', $row['id'] ) ) {
-				echo esc_html( $title );
-				return;
-			}
+			# Field group
+			echo '<td class="qm-ltr">';
+			$this->output_column_field_group( $row );
+			echo '</td>';
 
-			$url = add_query_arg( array(
-				'post'   => $row['id'],
-				'action' => 'edit',
-			), admin_url( 'post.php' ) );
+			# Caller
+			echo '<td class="qm-row-caller qm-ltr qm-has-toggle qm-nowrap">';
+			$this->output_column_caller( $row );
+			echo '</td>';
 
-			printf(
-				'<a href="%1$s" class="qm-edit-link">%2$s%3$s</a>',
-				esc_url( $url ),
-				esc_html( $title ),
-				QueryMonitor::icon( 'edit' )
-			);
-		}
-
-		protected function output_column_field_group_key( array $row ) {
-			$data = $this->collector->get_data();
-			$group = $row['group'];
-
-			if ( empty( $group ) ) {
-				return;
-			}
-
-			if (
-				! acf_is_local_field_group( $group )
-				|| ! array_key_exists( $group, $data->local_json['groups'] )
-			) {
-				echo esc_html( $group );
-				return;
-			}
-
-			$filepath = $data->local_json['groups'][ $group ]['local_file'];
-
-			if ( ! file_exists( $filepath ) ) {
-				echo esc_html( $group );
-				return;
-			}
-
-			echo QM_Output_Html::output_filename( $group, $filepath );
-		}
-
-		protected function output_column_field_group( array $row ) {
-			$group = $row['group'];
-
-			if ( empty( $group ) ) {
-				return;
-			}
-
-			if ( empty( $group['ID'] ) || ! current_user_can( 'edit_post', $group['ID'] ) ) {
-				echo esc_html( $group['title'] );
-				return;
-			}
-
-			$url = add_query_arg( array(
-				'post'   => $group['ID'],
-				'action' => 'edit',
-			), admin_url( 'post.php' ) );
-
-			printf(
-				'<a href="%1$s" class="qm-edit-link">%2$s%3$s</a>',
-				esc_url( $url ),
-				esc_html( $group['title'] ),
-				QueryMonitor::icon( 'edit' )
-			);
-		}
-
-		protected function output_column_field_group_rules( array $row ) {
-			$rules = $row['rules'];
-
-			if ( empty( $rules ) ) {
-				return;
-			}
-
-			echo '<pre>';
-			print_r( $rules );
-			echo '</pre>';
-		}
-
-		protected function output_column_caller( array $row ) {
-			$trace = $row['trace'];
-			$filtered_trace = $trace->get_display_trace();
-			$caller_name = self::output_filename( $row['caller']['function'] . '()', $row['caller']['file'], $row['caller']['line'] );
-			$stack = array();
-			array_shift( $filtered_trace );
-
-			foreach ( $filtered_trace as $item ) {
-				$item = wp_parse_args( $item, array(
-					'file' => '',
-					'line' => '',
-				) );
-
-				if ( empty( $item['display'] ) ) {
-					continue;
-				}
-
-				$stack[] = self::output_filename( $item['display'], $item['file'], $item['line'] );
-			}
-
-			if ( 1 < count( $stack ) ) {
-				echo self::build_toggler();
-				}
-
-			echo '<ol>';
-			printf( '<li>%s</li>', $caller_name );
-
-			if ( 1 < count( $stack ) ) {
-				echo '<div class="qm-toggled"><li>' . implode( '</li><li>', $stack ) . '</li></div>';
-			}
-
-			echo '</ol>';
-		}
-
-		protected function output_local_json() {
-			$id = 'qm-acf-local_json';
-			$name = 'Advanced Custom Fields: Local JSON';
-			$data = $this->collector->get_data();
-
-			printf(
-				'<div class="qm qm-concerns" id="%1$s" role="tabpanel" aria-labelledby="%1$s-caption" tabindex="-1">',
-				esc_attr( $id )
-			);
-
-			echo '<table class="qm-sortable">';
-
-			printf(
-				'<caption><h2 id="%1$s-caption">%2$s<br />%3$s</h2></caption>',
-				esc_attr( $id ),
-				esc_html( $name ),
-				'<a href="https://www.advancedcustomfields.com/resources/local-json/" rel="noopener noreferrer" class="qm-external-link">Documentation</a>'
-			);
-
-			echo '<thead>';
-			echo '<tr>';
-			echo '<th scope="col">Action</th>';
-			echo '<th scope="col">Hook</th>';
-			echo '<th scope="col" colspan="2">Paths</th>';
 			echo '</tr>';
-			echo '</thead>';
-
-			echo '<tbody>';
-
-			if ( ! empty( $data->local_json['save'] ) ) {
-				$directory = apply_filters( 'acf/settings/save_json', $data->local_json['save'] );
-				echo '<tr>';
-				echo '<th scope="row">Save</th>';
-				echo '<td><code>acf/settings/save_json</code></td>';
-				echo '<td colspan="2">' . QM_Output_Html::output_filename( $this->remove_abspath( $directory ), $directory ) . '</td>';
-				echo '</tr>';
-			}
-
-			if ( ! empty( $data->local_json['load'] ) ) {
-				$i = 0;
-
-				foreach ( $data->local_json['load'] as $path ) {
-					echo '<tr>';
-
-					if ( 0 === $i ) {
-						echo '<th scope="row" rowspan="' . esc_attr( count( $data->local_json['load'] ) ) . '">Load</th>';
-						echo '<td rowspan="' . esc_attr( count( $data->local_json['load'] ) ) . '"><code>acf/settings/load_json</code></td>';
-					}
-
-					echo '<td class="qm-num">' . esc_html( $i ) . '</td>';
-					echo '<td>' . QM_Output_Html::output_filename( $this->remove_abspath( $path ), $path ) . '</td>';
-
-					echo '</tr>';
-
-					$i++;
-				}
-			}
-
-			echo '</tbody>';
-			echo '</table>';
-
-			$this->output_local_json_field_groups();
-
-			echo '</div>';
 		}
 
-		protected function output_local_json_field_groups() {
-			$data = $this->collector->get_data();
+		echo '</tbody>';
 
-			if ( empty( $data->local_json['groups'] ) ) {
-				echo '<section class="qm-non-tabular"><div class="qm-notice"><p>No local JSON field groups found.</p></div></section>';
-				return;
+		echo '<tfoot>';
+		echo '<tr>';
+		printf( '<td colspan="5">Total: %d</td>', count( $data->fields ) );
+		echo '</tr>';
+		echo '</tfoot>';
+
+		echo '</table>';
+		echo '</div>';
+	}
+
+	protected function output_field_groups_table() {
+		$id = 'qm-acf-loaded_field_groups';
+		$name = 'Advanced Custom Fields: Loaded Field Groups';
+		$data = $this->collector->get_data();
+
+		printf(
+			'<div class="qm qm-concerns" id="%1$s" role="tabpanel" aria-labelledby="%1$s-caption" tabindex="-1">',
+			esc_attr( $id )
+		);
+
+		echo '<table class="qm-sortable">';
+
+		printf(
+			'<caption><h2 id="%1$s-caption">%2$s</h2></caption>',
+			esc_attr( $id ),
+			esc_html( $name )
+		);
+
+		echo '<thead>';
+
+		echo '<tr>';
+
+		echo '<th scope="col">';
+		echo esc_html__( 'Field Group', 'query-monitor-extend' );
+		echo '</th>';
+
+		echo '<th scope="col">';
+		echo esc_html__( 'Key', 'query-monitor-extend' );
+		echo '</th>';
+
+		echo '<th scope="col">';
+		echo esc_html__( 'Rules', 'query-monitor-extend' );
+		echo '</th>';
+
+		echo '</tr>';
+
+		echo '</thead>';
+
+		echo '<tbody>';
+
+		$row_num = 1;
+
+		foreach ( $data->loaded_field_groups as $row ) {
+			$class = '';
+
+			if ( 1 === $row_num % 2 ) {
+				$class = ' class="qm-odd"';
 			}
 
-			$groups = array();
+			echo '<tr' . $class . '>';
 
-			foreach ( $data->local_json['groups'] as $group ) {
-				$groups[ $group['title'] ] = $group;
-			}
+			# Field group name
+			echo '<td class="qm-ltr qm-nowrap">';
+			$this->output_column_field_group_title( $row );
+			echo '</td>';
 
-			ksort( $groups, SORT_NATURAL );
+			# Field group key
+			echo '<td class="qm-ltr">';
+			$this->output_column_field_group_key( $row );
+			echo '</td>';
 
-			echo '<table>';
-			echo '<caption><h2>Field Groups</caption>';
-			echo '<thead>';
-			echo '<tr>';
-			echo '<th scope="col">Title</th>';
-			echo '<th scope="col">Key</th>';
-			echo '<th scope="col">File</th>';
+			# Field group rules
+			echo '<td class="qm-ltr qm-nowrap qm-has-inner">';
+			$this->output_column_field_group_rules( $row );
+			echo '</td>';
+
 			echo '</tr>';
-			echo '</thead>';
-			echo '<tbody>';
-
-			foreach ( $groups as $group ) {
-				printf(
-					'<tr><th scope="row">%s</th><td>%s</td><td>%s</td></tr>',
-					esc_html( $group['title'] ),
-					esc_html( $group['key'] ),
-					QM_Output_HTML::output_filename( $this->remove_abspath( $group['local_file'] ), $group['local_file'] )
-				);
-			}
-
-			echo '</tbody>';
-			printf( '<tfoot><tr><td colspan="3">Total: <span class="qm-items-number">%d</span></td></tr></tfoot>', count( $data->local_json['groups'] ) );
-			echo '</table>';
 		}
 
-		public function remove_abspath( string $path ) : string {
-			return str_replace( ABSPATH, '', $path );
+		echo '</tbody>';
+
+		echo '<tfoot>';
+		echo '<tr>';
+		printf( '<td colspan="3">Total: %d</td>', count( $data->loaded_field_groups ) );
+		echo '</tr>';
+		echo '</tfoot>';
+
+		echo '</table>';
+		echo '</div>';
+	}
+
+	protected function output_column_field_name( array $row ) {
+		echo esc_html( $row['field']['name'] );
+
+		if ( ! $row['exists'] ) {
+			echo ' (Missing)';
+			return;
 		}
 
-		public function panel_menu( array $menu ) {
-			$data = $this->collector->get_data();
+		if (
+			! empty( $row['duplicate'] )
+			&& static::identify_duplicates()
+		) {
+			echo ' (Duplicate)';
+		}
 
-			if ( empty( $data->local_json['groups'] ) ) {
-				$data->local_json['groups'] = array();
-			}
+		$parent = $row['field']['parent'];
 
-			$menu['qm-acf'] = $this->menu( array(
-				'title' => esc_html__( 'Advanced Custom Fields', 'query-monitor-extend' ),
-				'id'    => 'query-monitor-extend-acf',
+		if ( ! empty( $row['group'] ) ) {
+			$parent = $row['group']['key'];
+		}
+
+		echo self::build_toggler();
+
+		echo '<div class="qm-toggled qm-supplemental qm-info">';
+		echo esc_html( 'Key: ' . $row['field']['key'] );
+		echo '<br />' . esc_html( 'Parent: ' . $parent );
+		echo '</div>';
+	}
+
+	protected function output_column_field_group_title( array $row ) {
+		$title = $row['title'];
+
+		if ( empty( $title ) ) {
+			return;
+		}
+
+		if ( empty( $row['id'] ) || ! current_user_can( 'edit_post', $row['id'] ) ) {
+			echo esc_html( $title );
+			return;
+		}
+
+		$url = add_query_arg( array(
+			'post'   => $row['id'],
+			'action' => 'edit',
+		), admin_url( 'post.php' ) );
+
+		printf(
+			'<a href="%1$s" class="qm-edit-link">%2$s%3$s</a>',
+			esc_url( $url ),
+			esc_html( $title ),
+			QueryMonitor::icon( 'edit' )
+		);
+	}
+
+	protected function output_column_field_group_key( array $row ) {
+		$data = $this->collector->get_data();
+		$group = $row['group'];
+
+		if ( empty( $group ) ) {
+			return;
+		}
+
+		if (
+			! acf_is_local_field_group( $group )
+			|| ! array_key_exists( $group, $data->local_json['groups'] )
+		) {
+			echo esc_html( $group );
+			return;
+		}
+
+		$filepath = $data->local_json['groups'][ $group ]['local_file'];
+
+		if ( ! file_exists( $filepath ) ) {
+			echo esc_html( $group );
+			return;
+		}
+
+		echo QM_Output_Html::output_filename( $group, $filepath );
+	}
+
+	protected function output_column_field_group( array $row ) {
+		$group = $row['group'];
+
+		if ( empty( $group ) ) {
+			return;
+		}
+
+		if ( empty( $group['ID'] ) || ! current_user_can( 'edit_post', $group['ID'] ) ) {
+			echo esc_html( $group['title'] );
+			return;
+		}
+
+		$url = add_query_arg( array(
+			'post'   => $group['ID'],
+			'action' => 'edit',
+		), admin_url( 'post.php' ) );
+
+		printf(
+			'<a href="%1$s" class="qm-edit-link">%2$s%3$s</a>',
+			esc_url( $url ),
+			esc_html( $group['title'] ),
+			QueryMonitor::icon( 'edit' )
+		);
+	}
+
+	protected function output_column_field_group_rules( array $row ) {
+		$rules = $row['rules'];
+
+		if ( empty( $rules ) ) {
+			return;
+		}
+
+		echo '<pre>';
+		print_r( $rules );
+		echo '</pre>';
+	}
+
+	protected function output_column_caller( array $row ) {
+		$trace = $row['trace'];
+		$filtered_trace = $trace->get_display_trace();
+		$caller_name = self::output_filename( $row['caller']['function'] . '()', $row['caller']['file'], $row['caller']['line'] );
+		$stack = array();
+		array_shift( $filtered_trace );
+
+		foreach ( $filtered_trace as $item ) {
+			$item = wp_parse_args( $item, array(
+				'file' => '',
+				'line' => '',
 			) );
 
-			if ( is_admin() ) {
-				$menu['qm-acf']['children']['loaded_field_groups'] = array(
-					'title' => esc_html__( 'Field Groups', 'query-monitor-extend' ) . sprintf( ' (%d)', count( $data->loaded_field_groups ) ),
-					'href'  => '#qm-acf-loaded_field_groups',
-					'id'    => 'query-monitor-extend-acf-loaded_field_groups',
-				);
+			if ( empty( $item['display'] ) ) {
+				continue;
 			}
 
-			$menu['qm-acf']['children']['local_json'] = array(
-				'title' => esc_html__('Local JSON', 'query-monitor-extend') . sprintf( ' (%d)', count( $data->local_json['groups'] ) ),
-				'href'  => '#qm-acf-local_json',
-				'id'    => 'query-monitor-extend-acf-local_json',
-			);
-
-			return $menu;
-
+			$stack[] = self::output_filename( $item['display'], $item['file'], $item['line'] );
 		}
+
+		if ( 1 < count( $stack ) ) {
+			echo self::build_toggler();
+			}
+
+		echo '<ol>';
+		printf( '<li>%s</li>', $caller_name );
+
+		if ( 1 < count( $stack ) ) {
+			echo '<div class="qm-toggled"><li>' . implode( '</li><li>', $stack ) . '</li></div>';
+		}
+
+		echo '</ol>';
+	}
+
+	protected function output_local_json() {
+		$id = 'qm-acf-local_json';
+		$name = 'Advanced Custom Fields: Local JSON';
+		$data = $this->collector->get_data();
+
+		printf(
+			'<div class="qm qm-concerns" id="%1$s" role="tabpanel" aria-labelledby="%1$s-caption" tabindex="-1">',
+			esc_attr( $id )
+		);
+
+		echo '<table class="qm-sortable">';
+
+		printf(
+			'<caption><h2 id="%1$s-caption">%2$s<br />%3$s</h2></caption>',
+			esc_attr( $id ),
+			esc_html( $name ),
+			'<a href="https://www.advancedcustomfields.com/resources/local-json/" rel="noopener noreferrer" class="qm-external-link">Documentation</a>'
+		);
+
+		echo '<thead>';
+		echo '<tr>';
+		echo '<th scope="col">Action</th>';
+		echo '<th scope="col">Hook</th>';
+		echo '<th scope="col" colspan="2">Paths</th>';
+		echo '</tr>';
+		echo '</thead>';
+
+		echo '<tbody>';
+
+		if ( ! empty( $data->local_json['save'] ) ) {
+			$directory = apply_filters( 'acf/settings/save_json', $data->local_json['save'] );
+			echo '<tr>';
+			echo '<th scope="row">Save</th>';
+			echo '<td><code>acf/settings/save_json</code></td>';
+			echo '<td colspan="2">' . QM_Output_Html::output_filename( $this->remove_abspath( $directory ), $directory ) . '</td>';
+			echo '</tr>';
+		}
+
+		if ( ! empty( $data->local_json['load'] ) ) {
+			$i = 0;
+
+			foreach ( $data->local_json['load'] as $path ) {
+				echo '<tr>';
+
+				if ( 0 === $i ) {
+					echo '<th scope="row" rowspan="' . esc_attr( count( $data->local_json['load'] ) ) . '">Load</th>';
+					echo '<td rowspan="' . esc_attr( count( $data->local_json['load'] ) ) . '"><code>acf/settings/load_json</code></td>';
+				}
+
+				echo '<td class="qm-num">' . esc_html( $i ) . '</td>';
+				echo '<td>' . QM_Output_Html::output_filename( $this->remove_abspath( $path ), $path ) . '</td>';
+
+				echo '</tr>';
+
+				$i++;
+			}
+		}
+
+		echo '</tbody>';
+		echo '</table>';
+
+		$this->output_local_json_field_groups();
+
+		echo '</div>';
+	}
+
+	protected function output_local_json_field_groups() {
+		$data = $this->collector->get_data();
+
+		if ( empty( $data->local_json['groups'] ) ) {
+			echo '<section class="qm-non-tabular"><div class="qm-notice"><p>No local JSON field groups found.</p></div></section>';
+			return;
+		}
+
+		$groups = array();
+
+		foreach ( $data->local_json['groups'] as $group ) {
+			$groups[ $group['title'] ] = $group;
+		}
+
+		ksort( $groups, SORT_NATURAL );
+
+		echo '<table>';
+		echo '<caption><h2>Field Groups</caption>';
+		echo '<thead>';
+		echo '<tr>';
+		echo '<th scope="col">Title</th>';
+		echo '<th scope="col">Key</th>';
+		echo '<th scope="col">File</th>';
+		echo '</tr>';
+		echo '</thead>';
+		echo '<tbody>';
+
+		foreach ( $groups as $group ) {
+			printf(
+				'<tr><th scope="row">%s</th><td>%s</td><td>%s</td></tr>',
+				esc_html( $group['title'] ),
+				esc_html( $group['key'] ),
+				QM_Output_HTML::output_filename( $this->remove_abspath( $group['local_file'] ), $group['local_file'] )
+			);
+		}
+
+		echo '</tbody>';
+		printf( '<tfoot><tr><td colspan="3">Total: <span class="qm-items-number">%d</span></td></tr></tfoot>', count( $data->local_json['groups'] ) );
+		echo '</table>';
+	}
+
+	public function remove_abspath( string $path ) : string {
+		return str_replace( ABSPATH, '', $path );
+	}
+
+	public function panel_menu( array $menu ) {
+		$data = $this->collector->get_data();
+
+		if ( empty( $data->local_json['groups'] ) ) {
+			$data->local_json['groups'] = array();
+		}
+
+		$menu['qm-acf'] = $this->menu( array(
+			'title' => esc_html__( 'Advanced Custom Fields', 'query-monitor-extend' ),
+			'id'    => 'query-monitor-extend-acf',
+		) );
+
+		if ( is_admin() ) {
+			$menu['qm-acf']['children']['loaded_field_groups'] = array(
+				'title' => esc_html__( 'Field Groups', 'query-monitor-extend' ) . sprintf( ' (%d)', count( $data->loaded_field_groups ) ),
+				'href'  => '#qm-acf-loaded_field_groups',
+				'id'    => 'query-monitor-extend-acf-loaded_field_groups',
+			);
+		}
+
+		$menu['qm-acf']['children']['local_json'] = array(
+			'title' => esc_html__('Local JSON', 'query-monitor-extend') . sprintf( ' (%d)', count( $data->local_json['groups'] ) ),
+			'href'  => '#qm-acf-local_json',
+			'id'    => 'query-monitor-extend-acf-local_json',
+		);
+
+		return $menu;
 
 	}
 
-	add_filter( 'qm/outputter/html', static function( array $output ) : array {
-		if ( $collector = QM_Collectors::get( 'acf' ) ) {
-			$output['acf'] = new QMX_Output_Html_ACF( $collector );
-		}
+}
 
-		return $output;
-	}, 70 );
+add_filter( 'qm/outputter/html', static function( array $output ) : array {
+	if ( $collector = QM_Collectors::get( 'acf' ) ) {
+		$output['acf'] = new QMX_Output_Html_ACF( $collector );
+	}
 
-}, 9 );
+	return $output;
+}, 70 );

--- a/constants/qmx-constants-collector.php
+++ b/constants/qmx-constants-collector.php
@@ -1,66 +1,32 @@
 <?php
-/**
- * Plugin Name: QMX: Constants Collector
- * Plugin URI: https://github.com/crstauf/query-monitor-extend/tree/master/constants
- * Description: Query Monitor collector for constants.
- * Version: 1.0.0
- * Author: Caleb Stauffer
- * Author URI: https://develop.calebstauffer.com
- * Update URI: false
- */
 
 defined( 'WPINC' ) || die();
 
-defined( 'QMX_DISABLED' ) || define( 'QMX_DISABLED', false );
-defined( 'QMX_TESTED_WITH_QM' ) || define( 'QMX_TESTED_WITH_QM', '3.13.0' );
+class QMX_Collector_Constants extends QM_DataCollector {
 
-add_action( 'plugin_loaded', 'load_qmx_constants_collector' );
+	public $id = 'constants';
 
-function load_qmx_constants_collector( string $file ) {
-
-	if ( 'query-monitor/query-monitor.php' !== plugin_basename( $file ) )
-		return;
-
-	remove_action( 'plugin_loaded', __FUNCTION__ );
-
-	if ( !class_exists( 'QueryMonitor' ) )
-		return;
-
-	if ( defined( 'QM_DISABLED' ) && constant( 'QM_DISABLED' ) ) {
-		return;
+	public function name() {
+		return __( 'Constants', 'query-monitor-extend' );
 	}
 
-	if ( constant( 'QMX_DISABLED' ) ) {
-		return;
+	public function get_storage(): QM_Data {
+		do_action( 'qmx/load_data/constants' );
+		return new QMX_Data_Constants();
 	}
 
-	class QMX_Collector_Constants extends QM_DataCollector {
+	public function process() {
+		if ( did_action( 'qm/cease' ) )
+			return;
 
-		public $id = 'constants';
-
-		public function name() {
-			return __( 'Constants', 'query-monitor-extend' );
-		}
-
-		public function get_storage(): QM_Data {
-			do_action( 'qmx/load_data/constants' );
-			return new QMX_Data_Constants();
-		}
-
-		public function process() {
-			if ( did_action( 'qm/cease' ) )
-				return;
-
-			$constants = get_defined_constants( true );
-			$this->data['constants'] = $constants['user'];
-
-		}
+		$constants = get_defined_constants( true );
+		$this->data['constants'] = $constants['user'];
 
 	}
-
-	add_filter( 'qm/collectors', static function ( array $collectors ) : array {
-		$collectors['constants'] = new QMX_Collector_Constants;
-		return $collectors;
-	} );
 
 }
+
+add_filter( 'qm/collectors', static function ( array $collectors ) : array {
+	$collectors['constants'] = new QMX_Collector_Constants;
+	return $collectors;
+} );

--- a/constants/qmx-constants-collector.php
+++ b/constants/qmx-constants-collector.php
@@ -11,7 +11,7 @@ class QMX_Collector_Constants extends QM_DataCollector {
 	}
 
 	public function get_storage(): QM_Data {
-		do_action( 'qmx/load_data/constants' );
+		require_once 'qmx-constants-data.php';
 		return new QMX_Data_Constants();
 	}
 

--- a/constants/qmx-constants-data.php
+++ b/constants/qmx-constants-data.php
@@ -1,30 +1,9 @@
 <?php
-/**
- * Plugin Name: QMX: Constants Data
- * Plugin URI: https://github.com/crstauf/query-monitor-extend/tree/master/constants
- * Description: Query Monitor data for constants.
- * Version: 1.0.0
- * Author: Caleb Stauffer
- * Author URI: https://develop.calebstauffer.com
- * Update URI: false
- */
 
 defined( 'WPINC' ) || die();
 
-if ( defined( 'QM_DISABLED' ) && constant( 'QM_DISABLED' ) ) {
-	return;
+class QMX_Data_Constants extends QM_Data {
+
+	public $constants;
+
 }
-
-if ( constant( 'QMX_DISABLED' ) ) {
-	return;
-}
-
-add_action( 'qmx/load_data/constants', static function () {
-
-	class QMX_Data_Constants extends QM_Data {
-
-		public $constants;
-
-	}
-
-} );

--- a/files/qmx-files-collector.php
+++ b/files/qmx-files-collector.php
@@ -1,78 +1,44 @@
 <?php
-/**
- * Plugin Name: QMX: Files Collector
- * Plugin URI: https://github.com/crstauf/query-monitor-extend/tree/master/files
- * Description: Query Monitor collector for files.
- * Version: 1.0.1
- * Author: Caleb Stauffer
- * Author URI: https://develop.calebstauffer.com
- * Update URI: false
- */
 
 defined( 'WPINC' ) || die();
 
-defined( 'QMX_DISABLED' ) || define( 'QMX_DISABLED', false );
-defined( 'QMX_TESTED_WITH_QM' ) || define( 'QMX_TESTED_WITH_QM', '3.13.0' );
+class QMX_Collector_Files extends QM_DataCollector {
 
-add_action( 'plugin_loaded', 'load_qmx_files_collector' );
+	public $id = 'files';
 
-function load_qmx_files_collector( string $file ) {
-
-	if ( 'query-monitor/query-monitor.php' !== plugin_basename( $file ) )
-		return;
-
-	remove_action( 'plugin_loaded', __FUNCTION__ );
-
-	if ( !class_exists( 'QueryMonitor' ) )
-		return;
-
-	if ( defined( 'QM_DISABLED' ) && constant( 'QM_DISABLED' ) ) {
-		return;
+	public function name() {
+		return __( 'Files', 'query-monitor-extend' );
 	}
 
-	if ( constant( 'QMX_DISABLED' ) ) {
-		return;
+	public function get_storage(): QM_Data {
+		do_action( 'qmx/load_data/files' );
+		return new QMX_Data_Files();
 	}
 
-	class QMX_Collector_Files extends QM_DataCollector {
+	public function process() {
+		if ( did_action( 'qm/cease' ) )
+			return;
 
-		public $id = 'files';
+		$php_errors = QM_Collectors::get( 'php_errors' )->get_data();
+		$files_with_errors = array();
 
-		public function name() {
-			return __( 'Files', 'query-monitor-extend' );
-		}
+		if ( !empty( $php_errors['errors'] ) )
+			foreach ( $php_errors['errors'] as $type => $errors )
+				foreach ( $errors as $error )
+					$files_with_errors[$error['file']] = 1;
 
-		public function get_storage(): QM_Data {
-			do_action( 'qmx/load_data/files' );
-			return new QMX_Data_Files();
-		}
-
-		public function process() {
-			if ( did_action( 'qm/cease' ) )
-				return;
-
-			$php_errors = QM_Collectors::get( 'php_errors' )->get_data();
-			$files_with_errors = array();
-
-			if ( !empty( $php_errors['errors'] ) )
-				foreach ( $php_errors['errors'] as $type => $errors )
-					foreach ( $errors as $error )
-						$files_with_errors[$error['file']] = 1;
-
-			foreach ( get_included_files() as $i => $filepath )
-				$this->data->files[] = array(
-					'path' => $filepath,
-					'component' => QM_Util::get_file_component( $filepath ),
-					'has_error' => array_key_exists( $filepath, $files_with_errors ),
-				);
-
-		}
+		foreach ( get_included_files() as $i => $filepath )
+			$this->data->files[] = array(
+				'path' => $filepath,
+				'component' => QM_Util::get_file_component( $filepath ),
+				'has_error' => array_key_exists( $filepath, $files_with_errors ),
+			);
 
 	}
-
-	add_filter( 'qm/collectors', static function ( array $collectors ) : array {
-		$collectors['files'] = new QMX_Collector_Files;
-		return $collectors;
-	} );
 
 }
+
+add_filter( 'qm/collectors', static function ( array $collectors ) : array {
+	$collectors['files'] = new QMX_Collector_Files;
+	return $collectors;
+} );

--- a/files/qmx-files-collector.php
+++ b/files/qmx-files-collector.php
@@ -11,7 +11,7 @@ class QMX_Collector_Files extends QM_DataCollector {
 	}
 
 	public function get_storage(): QM_Data {
-		do_action( 'qmx/load_data/files' );
+		require_once 'qmx-files-data.php';
 		return new QMX_Data_Files();
 	}
 

--- a/files/qmx-files-data.php
+++ b/files/qmx-files-data.php
@@ -1,30 +1,9 @@
 <?php
-/**
- * Plugin Name: QMX: Files Data
- * Plugin URI: https://github.com/crstauf/query-monitor-extend/tree/master/files
- * Description: Query Monitor data for files.
- * Version: 1.0.1
- * Author: Caleb Stauffer
- * Author URI: https://develop.calebstauffer.com
- * Update URI: false
- */
 
 defined( 'WPINC' ) || die();
 
-if ( defined( 'QM_DISABLED' ) && constant( 'QM_DISABLED' ) ) {
-	return;
+class QMX_Data_Files extends QM_Data {
+
+	public $files = array();
+
 }
-
-if ( constant( 'QMX_DISABLED' ) ) {
-	return;
-}
-
-add_action( 'qmx/load_data/files', static function () {
-
-	class QMX_Data_Files extends QM_Data {
-
-		public $files = array();
-
-	}
-
-} );

--- a/files/qmx-files-output.php
+++ b/files/qmx-files-output.php
@@ -1,248 +1,192 @@
 <?php
-/**
- * Plugin Name: QMX: Files Output
- * Plugin URI: https://github.com/crstauf/query-monitor-extend/tree/master/files
- * Description: Query Monitor collector for files.
- * Version: 1.0.1
- * Author: Caleb Stauffer
- * Author URI: https://develop.calebstauffer.com
- * Update URI: false
- */
 
 defined( 'WPINC' ) || die();
 
-add_action( 'shutdown', static function () {
+class QMX_Output_Html_Files extends QM_Output_Html {
 
-	if ( !class_exists( 'QMX_Collector_Files' ) )
-		return;
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
 
-	if ( ! class_exists( 'QM_Dispatcher_Html' ) || ! QM_Dispatcher_Html::user_can_view() || ! QM_Dispatcher_Html::request_supported() ) {
-		return;
+		add_filter( 'qm/output/title',       array( &$this, 'admin_title' ), 40 );
+		add_filter( 'qm/output/panel_menus', array( &$this, 'panel_menu'  ), 60 );
 	}
 
-	if ( defined( 'QM_DISABLED' ) && constant( 'QM_DISABLED' ) ) {
-		return;
-	}
+	public function output() {
+		$data = $this->collector->get_data();
 
-	if ( constant( 'QMX_DISABLED' ) ) {
-		return;
-	}
-
-	if ( is_admin() ) {
-		if ( ! ( did_action( 'admin_init' ) || did_action( 'admin_footer' ) ) ) {
-			return;
-		}
-	} else {
-		if ( ! ( did_action( 'wp' ) || did_action( 'wp_footer' ) || did_action( 'login_init' ) || did_action( 'gp_head' ) || did_action( 'login_footer' ) || did_action( 'gp_footer' ) ) ) {
-			return;
-		}
-	}
-
-	/** Back-compat filter. Please use `qm/dispatch/html` instead */
-	if ( ! apply_filters( 'qm/process', true, is_admin_bar_showing() ) ) {
-		return;
-	}
-
-	$qm = QueryMonitor::init()->plugin_path( 'assets/query-monitor.css' );
-
-	if ( ! file_exists( $qm ) ) {
-		return;
-	}
-
-	$qm_dir = trailingslashit( dirname( dirname( $qm ) ) );
-
-	if ( ! file_exists( $qm_dir . 'output/Html.php' ) )
-		return;
-
-	require_once $qm_dir . 'output/Html.php';
-
-	class QMX_Output_Html_Files extends QM_Output_Html {
-
-		public function __construct( QM_Collector $collector ) {
-			parent::__construct( $collector );
-
-			add_filter( 'qm/output/title',       array( &$this, 'admin_title' ), 40 );
-			add_filter( 'qm/output/panel_menus', array( &$this, 'panel_menu'  ), 60 );
-		}
-
-		public function output() {
-			$data = $this->collector->get_data();
-
-			echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
-
-				if ( !empty( $data->files ) ) {
-					$files_with_errors = 0;
-					$path_components = $components = array();
-
-					$largest_file = array(
-						'path' => null,
-						'size' => 0
-					);
-
-					foreach ( $data->files as &$file ) {
-						$file['_path_components'] = array();
-
-						foreach ( array_filter( explode( '/', str_replace( ABSPATH, '', dirname( $file['path'] ) ) ) ) as $path_component ) {
-							$path_components[$path_component]
-								= $file['_path_components'][$path_component]
-								= 1;
-							foreach ( explode( '-', $path_component ) as $smaller_path_component )
-								$path_components[$smaller_path_component]
-									= $file['_path_components'][$smaller_path_component]
-									= 1;
-						}
-
-						$filesize = @filesize( $file['path'] );
-
-						if ( empty( $filesize ) ) {
-							$filesize = 0;
-						}
-
-						if ( $filesize > $largest_file['size'] ) {
-							$largest_file = array(
-								'path' => $file['path'],
-								'size' => filesize( $file['path'] ),
-							);
-						}
-
-						$components[$file['component']->name] = 1;
-					}
-
-					echo '<table class="qm-sortable">';
-						echo '<caption class="qm-screen-reader-text">' . esc_html( $this->collector->name() ) . '</caption>';
-						echo '<thead>';
-							echo '<tr>';
-
-								echo '<th scope="col" class="qm-num qm-sorted-asc qm-sortable-column">';
-									echo $this->build_sorter( __( '', 'query-monitor-extend' ) );
-								echo '</th>';
-
-								echo '<th scope="col" class="qm-filterable-column">';
-									echo $this->build_filter( 'path', array_map( 'esc_attr', array_keys( $path_components ) ), __( 'Path', 'query-monitor-extend' ) );
-								echo '</th>';
-
-								echo '<th scope="col" class="qm-ltr qm-sortable-column">';
-									echo $this->build_sorter( __( 'Filesize', 'query-monitor-extend' ) );
-								echo '</th>';
-
-								echo '<th scope="col" class="qm-filterable-column">';
-									echo $this->build_filter( 'component', array_map( 'esc_attr', array_keys( $components ) ), __( 'Component', 'query-monitor-extend' ) );
-								echo '</th>';
-
-							echo '</tr>';
-						echo '</thead>';
-
-						echo '<tbody>';
-
-							$total_file_size = 0;
-
-							foreach ( $data->files as $i => $file ) {
-
-								$filesize = @filesize( $file['path'] );
-
-								if ( empty( $filesize ) ) {
-									$filesize = 0;
-								}
-
-								$total_file_size += $filesize;
-
-								if ( !empty( $file['has_error'] ) )
-									$files_with_errors++;
-
-								echo '<tr ' .
-									'data-qm-component="' . esc_attr( $file['component']->name ) . '" ' .
-									'data-qm-path="' . esc_attr( implode( ' ', array_keys( $file['_path_components'] ) ) ) . '" ' .
-									( !empty( $file['has_error'] ) ? ' class="qm-warn"' : '' ) .
-								'>';
-
-									echo '<td class="qm-num">' . ( $i + 1 ) . '</td>';
-									echo '<th scope="row">' . QM_Output_Html::output_filename( str_replace( ABSPATH, '', $file['path'] ), $file['path'] ) . '</th>';
-									echo '<td data-qm-sort-weight="' . esc_attr( $filesize ) . '">';
-										echo ! empty( $filesize ) ? $this->human_file_size( $filesize ) : '&mdash;';
-									echo '</td>';
-
-									echo '<td>' . esc_html( $file['component']->name ) . '</td>';
-								echo '</tr>';
-							}
-
-						echo '</tbody>';
-						echo '<tfoot>';
-
-							echo '<tr class="qm-items-shown qm-hide">';
-								echo '<td colspan="4">';
-								printf(
-									esc_html__( 'Files in filter: %s', 'query-monitor-extend' ),
-									'<span class="qm-items-number">' . esc_html( number_format_i18n( count( $data->files ) ) ) . '</span>'
-								);
-								echo '</td>';
-							echo '</tr>';
-
-							echo '<tr>';
-								echo '<td colspan="2">' .
-									'Total: <span class="qm-items-number">' . esc_html( number_format_i18n( count( $data->files ) ) ) . '</span>' .
-									(
-										!empty( $files_with_errors )
-										? ', With error(s): <span>' . esc_html( number_format_i18n( $files_with_errors ) ) . '</span>'
-										: ''
-									) .
-								'</td>';
-								echo '<td>&#61;' . $this->human_file_size( $total_file_size ) . '</td>';
-								echo '<td>Components: ' . count( $components ) . '</td>';
-							echo '</tr>';
-
-						echo '</tfoot>';
-					echo '</table>';
-
-					echo '<style type="text/css">.qm-hide-path { display: none; }</style>';
-
-				} else {
-
-					echo '<div class="qm-none">';
-					echo '<p>' . esc_html__( 'None', 'query-monitor' ) . '</p>';
-					echo '</div>';
-
-				}
-
-			echo '</div>';
-		}
-
-		public function admin_title( array $title ) {
-			$data = $this->collector->get_data();
+		echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
 
 			if ( !empty( $data->files ) ) {
-				$_title = sprintf( esc_html_x( '%s F', 'Files count', 'query-monitor-extend' ), number_format_i18n( count( $data->files ) ) );
-				$_title = preg_replace( '#\s?([^0-9,\.]+)#', '<small>$1</small>', $_title );
-				$title[] = $_title;
+				$files_with_errors = 0;
+				$path_components = $components = array();
+
+				$largest_file = array(
+					'path' => null,
+					'size' => 0
+				);
+
+				foreach ( $data->files as &$file ) {
+					$file['_path_components'] = array();
+
+					foreach ( array_filter( explode( '/', str_replace( ABSPATH, '', dirname( $file['path'] ) ) ) ) as $path_component ) {
+						$path_components[$path_component]
+							= $file['_path_components'][$path_component]
+							= 1;
+						foreach ( explode( '-', $path_component ) as $smaller_path_component )
+							$path_components[$smaller_path_component]
+								= $file['_path_components'][$smaller_path_component]
+								= 1;
+					}
+
+					$filesize = @filesize( $file['path'] );
+
+					if ( empty( $filesize ) ) {
+						$filesize = 0;
+					}
+
+					if ( $filesize > $largest_file['size'] ) {
+						$largest_file = array(
+							'path' => $file['path'],
+							'size' => filesize( $file['path'] ),
+						);
+					}
+
+					$components[$file['component']->name] = 1;
+				}
+
+				echo '<table class="qm-sortable">';
+					echo '<caption class="qm-screen-reader-text">' . esc_html( $this->collector->name() ) . '</caption>';
+					echo '<thead>';
+						echo '<tr>';
+
+							echo '<th scope="col" class="qm-num qm-sorted-asc qm-sortable-column">';
+								echo $this->build_sorter( __( '', 'query-monitor-extend' ) );
+							echo '</th>';
+
+							echo '<th scope="col" class="qm-filterable-column">';
+								echo $this->build_filter( 'path', array_map( 'esc_attr', array_keys( $path_components ) ), __( 'Path', 'query-monitor-extend' ) );
+							echo '</th>';
+
+							echo '<th scope="col" class="qm-ltr qm-sortable-column">';
+								echo $this->build_sorter( __( 'Filesize', 'query-monitor-extend' ) );
+							echo '</th>';
+
+							echo '<th scope="col" class="qm-filterable-column">';
+								echo $this->build_filter( 'component', array_map( 'esc_attr', array_keys( $components ) ), __( 'Component', 'query-monitor-extend' ) );
+							echo '</th>';
+
+						echo '</tr>';
+					echo '</thead>';
+
+					echo '<tbody>';
+
+						$total_file_size = 0;
+
+						foreach ( $data->files as $i => $file ) {
+
+							$filesize = @filesize( $file['path'] );
+
+							if ( empty( $filesize ) ) {
+								$filesize = 0;
+							}
+
+							$total_file_size += $filesize;
+
+							if ( !empty( $file['has_error'] ) )
+								$files_with_errors++;
+
+							echo '<tr ' .
+								'data-qm-component="' . esc_attr( $file['component']->name ) . '" ' .
+								'data-qm-path="' . esc_attr( implode( ' ', array_keys( $file['_path_components'] ) ) ) . '" ' .
+								( !empty( $file['has_error'] ) ? ' class="qm-warn"' : '' ) .
+							'>';
+
+								echo '<td class="qm-num">' . ( $i + 1 ) . '</td>';
+								echo '<th scope="row">' . QM_Output_Html::output_filename( str_replace( ABSPATH, '', $file['path'] ), $file['path'] ) . '</th>';
+								echo '<td data-qm-sort-weight="' . esc_attr( $filesize ) . '">';
+									echo ! empty( $filesize ) ? $this->human_file_size( $filesize ) : '&mdash;';
+								echo '</td>';
+
+								echo '<td>' . esc_html( $file['component']->name ) . '</td>';
+							echo '</tr>';
+						}
+
+					echo '</tbody>';
+					echo '<tfoot>';
+
+						echo '<tr class="qm-items-shown qm-hide">';
+							echo '<td colspan="4">';
+							printf(
+								esc_html__( 'Files in filter: %s', 'query-monitor-extend' ),
+								'<span class="qm-items-number">' . esc_html( number_format_i18n( count( $data->files ) ) ) . '</span>'
+							);
+							echo '</td>';
+						echo '</tr>';
+
+						echo '<tr>';
+							echo '<td colspan="2">' .
+								'Total: <span class="qm-items-number">' . esc_html( number_format_i18n( count( $data->files ) ) ) . '</span>' .
+								(
+									!empty( $files_with_errors )
+									? ', With error(s): <span>' . esc_html( number_format_i18n( $files_with_errors ) ) . '</span>'
+									: ''
+								) .
+							'</td>';
+							echo '<td>&#61;' . $this->human_file_size( $total_file_size ) . '</td>';
+							echo '<td>Components: ' . count( $components ) . '</td>';
+						echo '</tr>';
+
+					echo '</tfoot>';
+				echo '</table>';
+
+				echo '<style type="text/css">.qm-hide-path { display: none; }</style>';
+
+			} else {
+
+				echo '<div class="qm-none">';
+				echo '<p>' . esc_html__( 'None', 'query-monitor' ) . '</p>';
+				echo '</div>';
+
 			}
 
-			return $title;
+		echo '</div>';
+	}
 
+	public function admin_title( array $title ) {
+		$data = $this->collector->get_data();
+
+		if ( !empty( $data->files ) ) {
+			$_title = sprintf( esc_html_x( '%s F', 'Files count', 'query-monitor-extend' ), number_format_i18n( count( $data->files ) ) );
+			$_title = preg_replace( '#\s?([^0-9,\.]+)#', '<small>$1</small>', $_title );
+			$title[] = $_title;
 		}
 
-		public function panel_menu( array $menu ) {
-
-			$menu['files'] = $this->menu( array(
-				'title' => esc_html__( 'Files', 'query-monitor-extend' ),
-				'id'    => 'query-monitor-extend-files',
-			) );
-
-			return $menu;
-
-		}
-
-		private function human_file_size( $bytes ) {
-			$filesize_units = 'BKMGTP';
-			$factor = ( int ) floor( ( strlen( $bytes ) - 1 ) / 3 );
-			return sprintf( "%.2f", $bytes / pow( 1024, $factor ) ) . @$filesize_units[$factor];
-		}
+		return $title;
 
 	}
 
-	add_filter( 'qm/outputter/html', static function ( array $output ) : array {
-		if ( $collector = QM_Collectors::get( 'files' ) )
-			$output['files'] = new QMX_Output_Html_Files( $collector );
+	public function panel_menu( array $menu ) {
 
-		return $output;
-	}, 70 );
+		$menu['files'] = $this->menu( array(
+			'title' => esc_html__( 'Files', 'query-monitor-extend' ),
+			'id'    => 'query-monitor-extend-files',
+		) );
 
-}, 9 );
+		return $menu;
+
+	}
+
+	private function human_file_size( $bytes ) {
+		$filesize_units = 'BKMGTP';
+		$factor = ( int ) floor( ( strlen( $bytes ) - 1 ) / 3 );
+		return sprintf( "%.2f", $bytes / pow( 1024, $factor ) ) . @$filesize_units[$factor];
+	}
+
+}
+
+add_filter( 'qm/outputter/html', static function ( array $output ) : array {
+	if ( $collector = QM_Collectors::get( 'files' ) )
+		$output['files'] = new QMX_Output_Html_Files( $collector );
+
+	return $output;
+}, 70 );

--- a/heartbeat/qmx-heartbeat-collector.php
+++ b/heartbeat/qmx-heartbeat-collector.php
@@ -1,214 +1,180 @@
 <?php
-/**
- * Plugin Name: QMX: Heartbeat Collector
- * Plugin URI: https://github.com/crstauf/query-monitor-extend/tree/master/heartbeat
- * Description: Query Monitor collector for heartbeats.
- * Version: 1.0.0
- * Author: Caleb Stauffer
- * Author URI: https://develop.calebstauffer.com
- * Update URI: false
- */
 
 defined( 'WPINC' ) || die();
 
-defined( 'QMX_DISABLED' ) || define( 'QMX_DISABLED', false );
-defined( 'QMX_TESTED_WITH_QM' ) || define( 'QMX_TESTED_WITH_QM', '3.13.0' );
+class QMX_Collector_Heartbeat extends QM_Collector {
 
-add_action( 'plugin_loaded', 'load_qmx_heartbeat_collector' );
+	public $id = 'heartbeat';
 
-function load_qmx_heartbeat_collector( string $file ) {
+	function __construct() {
+		parent::__construct();
 
-	if ( 'query-monitor/query-monitor.php' !== plugin_basename( $file ) )
-		return;
+		if ( $this->qm_no_jquery() )
+			return;
 
-	remove_action( 'plugin_loaded', __FUNCTION__ );
-
-	if ( !class_exists( 'QueryMonitor' ) )
-		return;
-
-	if ( defined( 'QM_DISABLED' ) && constant( 'QM_DISABLED' ) ) {
-		return;
+		add_action( 'wp_enqueue_scripts', array( &$this, 'add_inline_script' ) );
+		add_action( 'admin_enqueue_scripts', array( &$this, 'add_inline_script' ) );
 	}
 
-	if ( constant( 'QMX_DISABLED' ) ) {
-		return;
+	public function add_inline_script() {
+		if ( did_action( 'qm/cease' ) )
+			return;
+
+		wp_add_inline_script( 'heartbeat', $this->_inlineScript_heartbeat() );
 	}
 
-	class QMX_Collector_Heartbeat extends QM_Collector {
+	public function _inlineScript_heartbeat() {
+		ob_start();
+		?>
 
-		public $id = 'heartbeat';
+		var qmx_heartbeat = {
 
-		function __construct() {
-			parent::__construct();
+			_beat: null,
+			_beats: [],
+			_start: 0,
+			_table: null,
+			_tab: null,
+			_table_ready: false,
 
-			if ( $this->qm_no_jquery() )
-				return;
+			_prev_dub: 0,
 
-			add_action( 'wp_enqueue_scripts', array( &$this, 'add_inline_script' ) );
-			add_action( 'admin_enqueue_scripts', array( &$this, 'add_inline_script' ) );
-		}
+			init: function() {
 
-		public function add_inline_script() {
-			if ( did_action( 'qm/cease' ) )
-				return;
+				var that = this;
+				var d = new Date();
+				this._start = d.getTime();
 
-			wp_add_inline_script( 'heartbeat', $this->_inlineScript_heartbeat() );
-		}
-
-		public function _inlineScript_heartbeat() {
-			ob_start();
-			?>
-
-			var qmx_heartbeat = {
-
-				_beat: null,
-				_beats: [],
-				_start: 0,
-				_table: null,
-				_tab: null,
-				_table_ready: false,
-
-				_prev_dub: 0,
-
-				init: function() {
-
-					var that = this;
+				jQuery( document ).on( 'heartbeat-send', function() {
 					var d = new Date();
-					this._start = d.getTime();
+					var lub = d.getTime();
 
-					jQuery( document ).on( 'heartbeat-send', function() {
-						var d = new Date();
-						var lub = d.getTime();
-
-						if ( !that._table_ready ) {
-							that._beat = { lub: lub };
-							return;
-						}
-
-						var count = ( that._beats.find( 'tr' ).length + 1 );
-
-						if (
-							2 == count
-							&& that._beats.find( 'tr' ).hasClass( 'listening' )
-						) {
-							that._beats.html( '' );
-							count = 1;
-						}
-
-						that.add_table_row( that.get_table_row(
-							count,
-							lub,
-							'',
-							(
-								0 == that._prev_dub
-								? '-'
-								: ( lub - that._prev_dub )
-							),
-							'-'
-						) );
-						that.update_tab( count );
-						that._beat = that._beats.find( 'tr:first-child' );
-					} );
-
-					jQuery( document ).on( 'heartbeat-tick', function() {
-						var d = new Date();
-						var dub = d.getTime();
-
-						if ( !that._table_ready ) {
-							that._beat.dub = dub;
-							that['_beats'].push( that._beat );
-							that._beat = null;
-							return;
-						}
-
-						var dub_secs = ( dub - that._start ) / 1000;
-						var duration = ( ( ( dub - that._start ) / 1000 ) - parseFloat( that._beat.find( 'td.lub' ).text() ) );
-
-						that._beat.find( 'td.dub' ).html( dub_secs.toFixed( 3 ) );
-						that._beat.find( 'td.dur' ).html( duration.toFixed( 3 ) );
-						that._prev_dub = dub;
-					} );
-
-				},
-
-				populate_table: function() {
-					this._table_ready = true;
-					this._table = jQuery( <?php echo json_encode( '#' . esc_attr( $this->id() ) . ' > table' ) ?> );
-					this._beats = this._table.find( 'tbody' );
-				},
-
-				add_table_row: function( tr ) {
-					this._table.find( 'tbody' ).prepend( tr );
-				},
-
-				get_table_row: function( index, lub, dub, since_last, duration ) {
-					var lub_diff = ( lub - this._start ) / 1000;
-					var dub_diff = '-';
-					var duration_secs = '-';
-
-					if ( '' !== dub ) {
-						dub_diff = ( dub - this._start ) / 1000;
-						dub_diff = dub_diff.toFixed( 3 );
+					if ( !that._table_ready ) {
+						that._beat = { lub: lub };
+						return;
 					}
 
-					if ( !isNaN( duration ) ) {
-						duration_secs = duration / 1000;
-						duration_secs = duration_secs.toFixed( 3 );
+					var count = ( that._beats.find( 'tr' ).length + 1 );
+
+					if (
+						2 == count
+						&& that._beats.find( 'tr' ).hasClass( 'listening' )
+					) {
+						that._beats.html( '' );
+						count = 1;
 					}
 
-					var since_last_secs = '-' != since_last ? since_last / 1000 : '-';
-					since_last_secs = '-' != since_last_secs ? since_last_secs.toFixed( 3 ) : '-';
-
-					return '<tr' +
+					that.add_table_row( that.get_table_row(
+						count,
+						lub,
+						'',
 						(
-							1 == ( index % 2 )
-							? ' class="qm-odd"'
-							: ''
-						) +
-					'>' +
-						'<td class="qm-num">' + index + '</td>' +
-						'<td class="qm-num lub">' + lub_diff.toFixed( 3 ) + '</td>' +
-						'<td class="qm-num dub">' + dub_diff + '</td>' +
-						'<td class="qm-num since">' + since_last_secs + '</td>' +
-						'<td class="qm-num dur">' + duration_secs + '</td>' +
-					'</tr>';
-				},
+							0 == that._prev_dub
+							? '-'
+							: ( lub - that._prev_dub )
+						),
+						'-'
+					) );
+					that.update_tab( count );
+					that._beat = that._beats.find( 'tr:first-child' );
+				} );
 
-				update_tab: function( count ) {
-					this._tab = jQuery( '#qm-panel-menu button[data-qm-href=<?php echo json_encode( '#' . esc_attr( $this->id() ) ) ?>]' );
-					this._tab.html( 'Heartbeats (' + count + ')' );
+				jQuery( document ).on( 'heartbeat-tick', function() {
+					var d = new Date();
+					var dub = d.getTime();
+
+					if ( !that._table_ready ) {
+						that._beat.dub = dub;
+						that['_beats'].push( that._beat );
+						that._beat = null;
+						return;
+					}
+
+					var dub_secs = ( dub - that._start ) / 1000;
+					var duration = ( ( ( dub - that._start ) / 1000 ) - parseFloat( that._beat.find( 'td.lub' ).text() ) );
+
+					that._beat.find( 'td.dub' ).html( dub_secs.toFixed( 3 ) );
+					that._beat.find( 'td.dur' ).html( duration.toFixed( 3 ) );
+					that._prev_dub = dub;
+				} );
+
+			},
+
+			populate_table: function() {
+				this._table_ready = true;
+				this._table = jQuery( <?php echo json_encode( '#' . esc_attr( $this->id() ) . ' > table' ) ?> );
+				this._beats = this._table.find( 'tbody' );
+			},
+
+			add_table_row: function( tr ) {
+				this._table.find( 'tbody' ).prepend( tr );
+			},
+
+			get_table_row: function( index, lub, dub, since_last, duration ) {
+				var lub_diff = ( lub - this._start ) / 1000;
+				var dub_diff = '-';
+				var duration_secs = '-';
+
+				if ( '' !== dub ) {
+					dub_diff = ( dub - this._start ) / 1000;
+					dub_diff = dub_diff.toFixed( 3 );
 				}
 
-			};
+				if ( !isNaN( duration ) ) {
+					duration_secs = duration / 1000;
+					duration_secs = duration_secs.toFixed( 3 );
+				}
 
-			qmx_heartbeat.init();
+				var since_last_secs = '-' != since_last ? since_last / 1000 : '-';
+				since_last_secs = '-' != since_last_secs ? since_last_secs.toFixed( 3 ) : '-';
 
-			<?php
-			return ob_get_clean();
-		}
+				return '<tr' +
+					(
+						1 == ( index % 2 )
+						? ' class="qm-odd"'
+						: ''
+					) +
+				'>' +
+					'<td class="qm-num">' + index + '</td>' +
+					'<td class="qm-num lub">' + lub_diff.toFixed( 3 ) + '</td>' +
+					'<td class="qm-num dub">' + dub_diff + '</td>' +
+					'<td class="qm-num since">' + since_last_secs + '</td>' +
+					'<td class="qm-num dur">' + duration_secs + '</td>' +
+				'</tr>';
+			},
 
-		public function name() {
-			return __( 'Heartbeat', 'query-monitor-extend' );
-		}
+			update_tab: function( count ) {
+				this._tab = jQuery( '#qm-panel-menu button[data-qm-href=<?php echo json_encode( '#' . esc_attr( $this->id() ) ) ?>]' );
+				this._tab.html( 'Heartbeats (' + count + ')' );
+			}
 
-		public function process() {
-		}
+		};
 
-		public function qm_no_jquery() {
-			return defined( 'QM_NO_JQUERY' ) && QM_NO_JQUERY;
-		}
+		qmx_heartbeat.init();
 
-		public function get_concerned_filters() : array {
-			return array(
-				'heartbeat_received',
-			);
-		}
-
+		<?php
+		return ob_get_clean();
 	}
 
-	add_filter( 'qm/collectors', static function ( array $collectors ) : array {
-		$collectors['heartbeat'] = new QMX_Collector_Heartbeat;
-		return $collectors;
-	} );
+	public function name() {
+		return __( 'Heartbeat', 'query-monitor-extend' );
+	}
+
+	public function process() {
+	}
+
+	public function qm_no_jquery() {
+		return defined( 'QM_NO_JQUERY' ) && QM_NO_JQUERY;
+	}
+
+	public function get_concerned_filters() : array {
+		return array(
+			'heartbeat_received',
+		);
+	}
 
 }
+
+add_filter( 'qm/collectors', static function ( array $collectors ) : array {
+	$collectors['heartbeat'] = new QMX_Collector_Heartbeat;
+	return $collectors;
+} );

--- a/heartbeat/qmx-heartbeat-output.php
+++ b/heartbeat/qmx-heartbeat-output.php
@@ -1,141 +1,85 @@
 <?php
-/**
- * Plugin Name: QMX: Heartbeat Output
- * Plugin URI: https://github.com/crstauf/query-monitor-extend/tree/master/heartbeat
- * Description: Query Monitor output for heartbeat collector.
- * Version: 1.0.0
- * Author: Caleb Stauffer
- * Author URI: https://develop.calebstauffer.com
- * Update URI: false
- */
 
 defined( 'WPINC' ) || die();
 
-add_action( 'shutdown', static function () {
+class QMX_Output_Html_Heartbeat extends QM_Output_Html {
 
-	if ( !class_exists( 'QMX_Collector_Heartbeat' ) )
-		return;
-
-	if ( ! class_exists( 'QM_Dispatcher_Html' ) || ! QM_Dispatcher_Html::user_can_view() || ! QM_Dispatcher_Html::request_supported() ) {
-		return;
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/panel_menus', array( &$this, 'panel_menu' ), 60 );
 	}
 
-	if ( defined( 'QM_DISABLED' ) && constant( 'QM_DISABLED' ) ) {
-		return;
+	public function name() : string {
+		return __( 'Heartbeat', 'query-monitor-extend' );
 	}
 
-	if ( constant( 'QMX_DISABLED' ) ) {
-		return;
+	public function output() {
+		$data = $this->collector->get_data();
+
+		echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
+
+			if ( $this->collector->qm_no_jquery() ) {
+
+				echo '<div class="qm-none">';
+				echo '<p>Heartbeat logging requires jQuery, which has been prevented by <code>QM_NO_JQUERY</code>.</p>';
+				echo '</div>';
+
+			} else if ( wp_script_is( 'heartbeat', 'done' ) ) {
+				echo '<table class="qm-sortable">';
+					echo '<caption class="qm-screen-reader-text">' . esc_html( $this->collector->name() ) . '</caption>';
+
+					echo '<thead>';
+						echo '<tr>';
+
+							echo '<th scope="col" class="qm-num"></th>';
+							echo '<th scope="col">Lub</th>';
+							echo '<th scope="col">Dub</th>';
+							echo '<th scope="col">Time since previous</th>';
+							echo '<th scope="col">Duration</th>';
+
+						echo '</tr>';
+					echo '</thead>';
+
+					echo '<tbody>';
+						echo '<tr class="listening">';
+							echo '<td colspan="5">';
+								echo '<div class="qm-none"><p>Listening for first heartbeat...</p></div>';
+							echo '</td>';
+						echo '</tr>';
+					echo '</tbody>';
+
+				echo '</table>';
+				echo '<script type="text/javascript">qmx_heartbeat.populate_table();</script>';
+			} else {
+
+				echo '<div class="qm-none">';
+				echo '<p>' . esc_html__( 'No heartbeat detected.', 'query-monitor' ) . '</p>';
+				echo '</div>';
+
+			}
+
+		echo '</div>';
+
+		$this->current_id = 'qm-heartbeat';
+		$this->current_name = 'Heartbeat';
+
+		$this->output_concerns();
 	}
 
-	if ( is_admin() ) {
-		if ( ! ( did_action( 'admin_init' ) || did_action( 'admin_footer' ) ) ) {
-			return;
-		}
-	} else {
-		if ( ! ( did_action( 'wp' ) || did_action( 'wp_footer' ) || did_action( 'login_init' ) || did_action( 'gp_head' ) || did_action( 'login_footer' ) || did_action( 'gp_footer' ) ) ) {
-			return;
-		}
+	public function panel_menu( array $menu ) {
+		$menu['qm-heartbeat'] = $this->menu( array(
+			'title' => esc_html__( 'Heartbeats (0)' ),
+			'id'    => 'query-monitor-extend-heartbeat',
+		) );
+
+		return $menu;
 	}
 
-	/** Back-compat filter. Please use `qm/dispatch/html` instead */
-	if ( ! apply_filters( 'qm/process', true, is_admin_bar_showing() ) ) {
-		return;
-	}
+}
 
-	$qm = QueryMonitor::init()->plugin_path( 'assets/query-monitor.css' );
+add_filter( 'qm/outputter/html', static function ( array $output ) : array {
+	if ( $collector = QM_Collectors::get( 'heartbeat' ) )
+		$output['heartbeat'] = new QMX_Output_Html_Heartbeat( $collector );
 
-	if ( ! file_exists( $qm ) ) {
-		return;
-	}
-
-	$qm_dir = trailingslashit( dirname( dirname( $qm ) ) );
-
-	if ( ! file_exists( $qm_dir . 'output/Html.php' ) )
-		return;
-
-	require_once $qm_dir . 'output/Html.php';
-
-	class QMX_Output_Html_Heartbeat extends QM_Output_Html {
-
-		public function __construct( QM_Collector $collector ) {
-			parent::__construct( $collector );
-			add_filter( 'qm/output/panel_menus', array( &$this, 'panel_menu' ), 60 );
-		}
-
-		public function name() : string {
-			return __( 'Heartbeat', 'query-monitor-extend' );
-		}
-
-		public function output() {
-			$data = $this->collector->get_data();
-
-			echo '<div class="qm" id="' . esc_attr( $this->collector->id() ) . '">';
-
-				if ( $this->collector->qm_no_jquery() ) {
-
-					echo '<div class="qm-none">';
-					echo '<p>Heartbeat logging requires jQuery, which has been prevented by <code>QM_NO_JQUERY</code>.</p>';
-					echo '</div>';
-
-				} else if ( wp_script_is( 'heartbeat', 'done' ) ) {
-					echo '<table class="qm-sortable">';
-						echo '<caption class="qm-screen-reader-text">' . esc_html( $this->collector->name() ) . '</caption>';
-
-						echo '<thead>';
-							echo '<tr>';
-
-								echo '<th scope="col" class="qm-num"></th>';
-								echo '<th scope="col">Lub</th>';
-								echo '<th scope="col">Dub</th>';
-								echo '<th scope="col">Time since previous</th>';
-								echo '<th scope="col">Duration</th>';
-
-							echo '</tr>';
-						echo '</thead>';
-
-						echo '<tbody>';
-							echo '<tr class="listening">';
-								echo '<td colspan="5">';
-									echo '<div class="qm-none"><p>Listening for first heartbeat...</p></div>';
-								echo '</td>';
-							echo '</tr>';
-						echo '</tbody>';
-
-					echo '</table>';
-					echo '<script type="text/javascript">qmx_heartbeat.populate_table();</script>';
-				} else {
-
-					echo '<div class="qm-none">';
-					echo '<p>' . esc_html__( 'No heartbeat detected.', 'query-monitor' ) . '</p>';
-					echo '</div>';
-
-				}
-
-			echo '</div>';
-
-			$this->current_id = 'qm-heartbeat';
-			$this->current_name = 'Heartbeat';
-
-			$this->output_concerns();
-		}
-
-		public function panel_menu( array $menu ) {
-			$menu['qm-heartbeat'] = $this->menu( array(
-				'title' => esc_html__( 'Heartbeats (0)' ),
-				'id'    => 'query-monitor-extend-heartbeat',
-			) );
-
-			return $menu;
-		}
-
-	}
-
-	add_filter( 'qm/outputter/html', static function ( array $output ) : array {
-		if ( $collector = QM_Collectors::get( 'heartbeat' ) )
-			$output['heartbeat'] = new QMX_Output_Html_Heartbeat( $collector );
-
-		return $output;
-	}, 70 );
-
-}, 9 );
+	return $output;
+}, 70 );

--- a/image-sizes/qmx-image-sizes-collector.php
+++ b/image-sizes/qmx-image-sizes-collector.php
@@ -78,7 +78,7 @@ class QMX_Collector_Image_Sizes extends QM_DataCollector {
 	}
 
 	public function get_storage(): QM_Data {
-		do_action( 'qmx/load_data/image_sizes' );
+		require_once 'qmx-image-sizes-data.php';
 		return new QMX_Data_Image_Sizes();
 	}
 

--- a/image-sizes/qmx-image-sizes-collector.php
+++ b/image-sizes/qmx-image-sizes-collector.php
@@ -1,313 +1,277 @@
 <?php
-/**
- * Plugin Name: QMX: Image Sizes Collector
- * Plugin URI: https://github.com/crstauf/query-monitor-extend/tree/master/image-sizes
- * Description: Query Monitor collector for image sizes.
- * Version: 1.0
- * Author: Caleb Stauffer
- * Author URI: https://develop.calebstauffer.com
- * Update URI: false
- */
 
 defined( 'WPINC' ) || die();
 
-defined( 'QMX_DISABLED' ) || define( 'QMX_DISABLED', false );
-defined( 'QMX_TESTED_WITH_QM' ) || define( 'QMX_TESTED_WITH_QM', '3.13.0' );
+class QMX_Collector_Image_Sizes extends QM_DataCollector {
 
-add_action( 'plugin_loaded', 'load_qmx_image_sizes_collector' );
+	public $id = 'image_sizes';
 
-function load_qmx_image_sizes_collector( string $file ) {
+	public function __construct() {
+		parent::__construct();
 
-	if ( 'query-monitor/query-monitor.php' !== plugin_basename( $file ) )
-		return;
+		$this->data->sizes = array(
+			'thumbnail' => array(
+				'width'  => intval( get_option( 'thumbnail_size_w' ) ),
+				'height' => intval( get_option( 'thumbnail_size_h' ) ),
+				  'used' => 0,
+				'source' => 'native',
+				  'crop' => true,
+				   'num' => 1,
+			),
+			'medium' => array(
+				 'width' => intval( get_option( 'medium_size_w' ) ),
+				'height' => intval( get_option( 'medium_size_h' ) ),
+				  'used' => 0,
+				'source' => 'native',
+				  'crop' => false,
+				   'num' => 2,
+			),
+			'medium_large' => array(
+				 'width' => intval( get_option( 'medium_large_size_w' ) ),
+				'height' => intval( get_option( 'medium_large_size_h' ) ),
+				  'used' => 0,
+				'source' => 'native',
+				  'crop' => false,
+				   'num' => 3,
+			),
+			'large' => array(
+				 'width' => intval( get_option( 'large_size_w' ) ),
+				'height' => intval( get_option( 'large_size_h' ) ),
+				  'used' => 0,
+				'source' => 'native',
+				  'crop' => false,
+				   'num' => 4,
+			),
 
-	remove_action( 'plugin_loaded', __FUNCTION__ );
+			/**
+			 * @see _wp_add_additional_image_sizes()
+			 * @since WP 5.3.0
+			 */
+			'1536x1536' => array(
+				 'width' => 1536,
+				'height' => 1536,
+				  'used' => 0,
+				'source' => 'native',
+				  'crop' => false,
+				   'num' => 5,
+			),
+			'2048x2048' => array(
+				 'width' => 2048,
+				'height' => 2048,
+				  'used' => 0,
+				'source' => 'native',
+				  'crop' => false,
+				   'num' => 6,
+			),
+		);
 
-	if ( !class_exists( 'QueryMonitor' ) )
-		return;
+		add_action( 'plugins_loaded',        array( &$this, 'action__plugins_loaded'    ) );
+		add_action( 'after_setup_theme',     array( &$this, 'action__after_setup_theme' ) );
+		add_action( 'wp_enqueue_scripts',    array( &$this, 'add_inline_script' ), -998 );
+		add_action( 'admin_enqueue_scripts', array( &$this, 'add_inline_script' ), -998 );
+		add_action( 'login_enqueue_scripts', array( &$this, 'add_inline_script' ), -998 );
+		add_action( 'enqueue_embed_scripts', array( &$this, 'add_inline_script' ), -998 );
 
-	if ( defined( 'QM_DISABLED' ) && constant( 'QM_DISABLED' ) ) {
-		return;
+		add_action( 'wp', array( $this, 'action__wp' ) );
+		add_filter( 'wp_get_attachment_image_src', array( $this, 'filter__wp_get_attachment_image_src' ), 10, 3 );
+
 	}
 
-	if ( constant( 'QMX_DISABLED' ) ) {
-		return;
+	public function get_storage(): QM_Data {
+		do_action( 'qmx/load_data/image_sizes' );
+		return new QMX_Data_Image_Sizes();
 	}
 
-	class QMX_Collector_Image_Sizes extends QM_DataCollector {
+	public function get_concerned_filters() {
+		return array(
+			'wp_get_attachment_image_src',
+		);
+	}
 
-		public $id = 'image_sizes';
+	function action__plugins_loaded() {
+		if ( 'plugins_loaded' !== current_action() || did_action( 'qm/cease' ) )
+			return;
 
-		public function __construct() {
-			parent::__construct();
+		$this->_process_added_image_sizes( 'plugin' );
+	}
 
-			$this->data->sizes = array(
-				'thumbnail' => array(
-					'width'  => intval( get_option( 'thumbnail_size_w' ) ),
-					'height' => intval( get_option( 'thumbnail_size_h' ) ),
-					  'used' => 0,
-					'source' => 'native',
-					  'crop' => true,
-					   'num' => 1,
-				),
-				'medium' => array(
-					 'width' => intval( get_option( 'medium_size_w' ) ),
-					'height' => intval( get_option( 'medium_size_h' ) ),
-					  'used' => 0,
-					'source' => 'native',
-					  'crop' => false,
-					   'num' => 2,
-				),
-				'medium_large' => array(
-					 'width' => intval( get_option( 'medium_large_size_w' ) ),
-					'height' => intval( get_option( 'medium_large_size_h' ) ),
-					  'used' => 0,
-					'source' => 'native',
-					  'crop' => false,
-					   'num' => 3,
-				),
-				'large' => array(
-					 'width' => intval( get_option( 'large_size_w' ) ),
-					'height' => intval( get_option( 'large_size_h' ) ),
-					  'used' => 0,
-					'source' => 'native',
-					  'crop' => false,
-					   'num' => 4,
-				),
+	function action__after_setup_theme() {
+		if ( 'after_setup_theme' !== current_action() || did_action( 'qm/cease' ) )
+			return;
 
-				/**
-				 * @see _wp_add_additional_image_sizes()
-				 * @since WP 5.3.0
-				 */
-				'1536x1536' => array(
-					 'width' => 1536,
-					'height' => 1536,
-					  'used' => 0,
-					'source' => 'native',
-					  'crop' => false,
-					   'num' => 5,
-				),
-				'2048x2048' => array(
-					 'width' => 2048,
-					'height' => 2048,
-					  'used' => 0,
-					'source' => 'native',
-					  'crop' => false,
-					   'num' => 6,
-				),
-			);
+		$this->_process_added_image_sizes( 'theme' );
+	}
 
-			add_action( 'plugins_loaded',        array( &$this, 'action__plugins_loaded'    ) );
-			add_action( 'after_setup_theme',     array( &$this, 'action__after_setup_theme' ) );
-			add_action( 'wp_enqueue_scripts',    array( &$this, 'add_inline_script' ), -998 );
-			add_action( 'admin_enqueue_scripts', array( &$this, 'add_inline_script' ), -998 );
-			add_action( 'login_enqueue_scripts', array( &$this, 'add_inline_script' ), -998 );
-			add_action( 'enqueue_embed_scripts', array( &$this, 'add_inline_script' ), -998 );
+	function action__wp() : void {
+		if ( did_action( 'qm/cease' ) )
+			return;
 
-			add_action( 'wp', array( $this, 'action__wp' ) );
-			add_filter( 'wp_get_attachment_image_src', array( $this, 'filter__wp_get_attachment_image_src' ), 10, 3 );
+		$post = get_queried_object();
 
-		}
+		if ( empty( $post ) )
+			return;
 
-		public function get_storage(): QM_Data {
-			do_action( 'qmx/load_data/image_sizes' );
-			return new QMX_Data_Image_Sizes();
-		}
+		$blocks = parse_blocks( $post->post_content );
 
-		public function get_concerned_filters() {
-			return array(
-				'wp_get_attachment_image_src',
-			);
-		}
+		if ( empty( $blocks ) )
+			return;
 
-		function action__plugins_loaded() {
-			if ( 'plugins_loaded' !== current_action() || did_action( 'qm/cease' ) )
-				return;
+		foreach ( $blocks as $block ) {
+			if ( 'core/image' !== $block['blockName'] )
+				continue;
 
-			$this->_process_added_image_sizes( 'plugin' );
-		}
+			$size = $block['attrs']['sizeSlug'];
 
-		function action__after_setup_theme() {
-			if ( 'after_setup_theme' !== current_action() || did_action( 'qm/cease' ) )
-				return;
-
-			$this->_process_added_image_sizes( 'theme' );
-		}
-
-		function action__wp() : void {
-			if ( did_action( 'qm/cease' ) )
-				return;
-
-			$post = get_queried_object();
-
-			if ( empty( $post ) )
-				return;
-
-			$blocks = parse_blocks( $post->post_content );
-
-			if ( empty( $blocks ) )
-				return;
-
-			foreach ( $blocks as $block ) {
-				if ( 'core/image' !== $block['blockName'] )
-					continue;
-
-				$size = $block['attrs']['sizeSlug'];
-
-				if ( !array_key_exists( $size, $this->data->sizes ) )
-					continue;
-
-				$this->data->sizes[ $size ]['used']++;
-			}
-		}
-
-		function filter__wp_get_attachment_image_src( $image, $attachment_id, $size ) {
-			if ( did_action( 'qm/cease' ) )
-				return $image;
-
-			# If specifying custom dimensions, bail.
-			if ( is_array( $size ) )
-				return $image;
-
-			# If size is not registered, bail.
 			if ( !array_key_exists( $size, $this->data->sizes ) )
-				return $image;
+				continue;
 
 			$this->data->sizes[ $size ]['used']++;
+		}
+	}
 
+	function filter__wp_get_attachment_image_src( $image, $attachment_id, $size ) {
+		if ( did_action( 'qm/cease' ) )
 			return $image;
+
+		# If specifying custom dimensions, bail.
+		if ( is_array( $size ) )
+			return $image;
+
+		# If size is not registered, bail.
+		if ( !array_key_exists( $size, $this->data->sizes ) )
+			return $image;
+
+		$this->data->sizes[ $size ]['used']++;
+
+		return $image;
+	}
+
+	protected function _process_added_image_sizes( $source = 'unknown' ) {
+		global $_wp_additional_image_sizes;
+
+		$num = count( $this->data->sizes );
+
+		if (
+			 is_array( $_wp_additional_image_sizes )
+			&& !empty( $_wp_additional_image_sizes )
+		)
+			foreach ( $_wp_additional_image_sizes as $id => $size )
+				if ( !array_key_exists( $id, $this->data->sizes ) )
+					$this->data->sizes[$id] = array_merge(
+						array(
+							'num' => ++$num,
+							'source' => apply_filters( 'qmx/image-size/source', $source, $id, $size ),
+							'used' => 0,
+						),
+						$size
+					);
+	}
+
+	public function process() {
+		if ( did_action( 'qm/cease' ) )
+			return;
+
+		$this->_process_added_image_sizes();
+
+		$this->data->sizes = array_map( array( &$this, 'add_ratio' ), $this->data->sizes );
+
+		$counts = array( 'dimensions' => array(), 'ratios' => array() );
+
+		foreach ( $this->data->sizes as $size ) {
+			$key = $size['width'] . ':' . $size['height'] . ' - ' . ( bool ) $size['crop'];
+			array_key_exists( $key, $counts['dimensions'] )
+				? $counts['dimensions'][$key]++
+				: $counts['dimensions'][$key] = 1;
+
+			$key = $size['ratio'] . ' - ' . ( bool ) $size['crop'];
+			if ( 0 !== $size['ratio'] )
+				array_key_exists( $key, $counts['ratios'] )
+					? $counts['ratios'][$key]++
+					: $counts['ratios'][$key] = 1;
 		}
 
-		protected function _process_added_image_sizes( $source = 'unknown' ) {
-			global $_wp_additional_image_sizes;
+		foreach ( array( 'dimensions', 'ratios' ) as $type )
+			$counts[$type] = array_filter( $counts[$type], function( $v ) { return $v > 1; } );
 
-			$num = count( $this->data->sizes );
-
-			if (
-				 is_array( $_wp_additional_image_sizes )
-				&& !empty( $_wp_additional_image_sizes )
-			)
-				foreach ( $_wp_additional_image_sizes as $id => $size )
-					if ( !array_key_exists( $id, $this->data->sizes ) )
-						$this->data->sizes[$id] = array_merge(
-							array(
-								'num' => ++$num,
-								'source' => apply_filters( 'qmx/image-size/source', $source, $id, $size ),
-								'used' => 0,
-							),
-							$size
-						);
-		}
-
-		public function process() {
-			if ( did_action( 'qm/cease' ) )
-				return;
-
-			$this->_process_added_image_sizes();
-
-			$this->data->sizes = array_map( array( &$this, 'add_ratio' ), $this->data->sizes );
-
-			$counts = array( 'dimensions' => array(), 'ratios' => array() );
-
-			foreach ( $this->data->sizes as $size ) {
-				$key = $size['width'] . ':' . $size['height'] . ' - ' . ( bool ) $size['crop'];
-				array_key_exists( $key, $counts['dimensions'] )
-					? $counts['dimensions'][$key]++
-					: $counts['dimensions'][$key] = 1;
-
-				$key = $size['ratio'] . ' - ' . ( bool ) $size['crop'];
-				if ( 0 !== $size['ratio'] )
-					array_key_exists( $key, $counts['ratios'] )
-						? $counts['ratios'][$key]++
-						: $counts['ratios'][$key] = 1;
-			}
-
-			foreach ( array( 'dimensions', 'ratios' ) as $type )
-				$counts[$type] = array_filter( $counts[$type], function( $v ) { return $v > 1; } );
-
-			$this->data->duplicates = $counts;
-
-		}
-
-		private function add_ratio( array $size ) {
-			if (
-				   !array_key_exists( 'width',  $size )
-				|| !array_key_exists( 'height', $size )
-			)
-				return $size;
-
-			$num1 = $size['width'];
-			$num2 = $size['height'];
-
-			while ( 0 !== $num2 ) {
-				$t = $num1 % $num2;
-				$num1 = $num2;
-				$num2 = $t;
-			}
-
-			$size['_gcd'] = $num1; // greatest common denominator
-			unset( $num1, $num2 );
-
-			$size['ratio'] = (
-				0 === $size['height']
-				? 0
-				: $size['width'] / $size['height']
-			);
-
-			return $size;
-		}
-
-		public function add_inline_script() {
-			if ( did_action( 'qm/cease' ) )
-				return;
-
-			wp_add_inline_script( 'query-monitor', $this->_inlineScript_queryMonitor() );
-		}
-
-		protected function _inlineScript_queryMonitor() {
-			ob_start();
-			?>
-
-			if ( window.jQuery ) {
-
-				jQuery( function( $ ) {
-
-					$( 'td[data-qmx-image-size-width]' )
-						.on( 'mouseenter', function() { qmx_image_size_highlighter__mouseenter( 'width', this ); } )
-						.on( 'mouseleave', function() { qmx_image_size_highlighter__mouseleave( 'width', this ); } );
-
-					$( 'td[data-qmx-image-size-height]' )
-						.on( 'mouseenter', function() { qmx_image_size_highlighter__mouseenter( 'height', this ); } )
-						.on( 'mouseleave', function() { qmx_image_size_highlighter__mouseleave( 'height', this ); } );
-
-					$( 'td[data-qmx-image-size-ratio]' )
-						.on( 'mouseenter', function() { qmx_image_size_highlighter__mouseenter( 'ratio', this ); } )
-						.on( 'mouseleave', function() { qmx_image_size_highlighter__mouseleave( 'ratio', this ); } );
-
-				} );
-
-				function qmx_image_size_highlighter__mouseenter( prop, el ) {
-					jQuery( el ).addClass( 'qm-highlight' );
-					var tr = jQuery( el ).closest( 'tr' );
-					var value = jQuery( el ).attr( 'data-qmx-image-size-' + prop );
-					var table = jQuery( el ).closest( 'table' ).find( 'tr[data-qmx-image-size-' + prop + '="' + value + '"]' ).not( tr ).addClass( 'qm-highlight' );
-				}
-
-				function qmx_image_size_highlighter__mouseleave( prop, el ) {
-					jQuery( el ).removeClass( 'qm-highlight' );
-					jQuery( el ).closest( 'table' ).find( 'tr.qm-highlight' ).removeClass( 'qm-highlight' );
-				}
-
-			}
-
-			<?php
-			return ob_get_clean();
-		}
+		$this->data->duplicates = $counts;
 
 	}
 
-	QM_Collectors::add( new QMX_Collector_Image_Sizes );
+	private function add_ratio( array $size ) {
+		if (
+			   !array_key_exists( 'width',  $size )
+			|| !array_key_exists( 'height', $size )
+		)
+			return $size;
+
+		$num1 = $size['width'];
+		$num2 = $size['height'];
+
+		while ( 0 !== $num2 ) {
+			$t = $num1 % $num2;
+			$num1 = $num2;
+			$num2 = $t;
+		}
+
+		$size['_gcd'] = $num1; // greatest common denominator
+		unset( $num1, $num2 );
+
+		$size['ratio'] = (
+			0 === $size['height']
+			? 0
+			: $size['width'] / $size['height']
+		);
+
+		return $size;
+	}
+
+	public function add_inline_script() {
+		if ( did_action( 'qm/cease' ) )
+			return;
+
+		wp_add_inline_script( 'query-monitor', $this->_inlineScript_queryMonitor() );
+	}
+
+	protected function _inlineScript_queryMonitor() {
+		ob_start();
+		?>
+
+		if ( window.jQuery ) {
+
+			jQuery( function( $ ) {
+
+				$( 'td[data-qmx-image-size-width]' )
+					.on( 'mouseenter', function() { qmx_image_size_highlighter__mouseenter( 'width', this ); } )
+					.on( 'mouseleave', function() { qmx_image_size_highlighter__mouseleave( 'width', this ); } );
+
+				$( 'td[data-qmx-image-size-height]' )
+					.on( 'mouseenter', function() { qmx_image_size_highlighter__mouseenter( 'height', this ); } )
+					.on( 'mouseleave', function() { qmx_image_size_highlighter__mouseleave( 'height', this ); } );
+
+				$( 'td[data-qmx-image-size-ratio]' )
+					.on( 'mouseenter', function() { qmx_image_size_highlighter__mouseenter( 'ratio', this ); } )
+					.on( 'mouseleave', function() { qmx_image_size_highlighter__mouseleave( 'ratio', this ); } );
+
+			} );
+
+			function qmx_image_size_highlighter__mouseenter( prop, el ) {
+				jQuery( el ).addClass( 'qm-highlight' );
+				var tr = jQuery( el ).closest( 'tr' );
+				var value = jQuery( el ).attr( 'data-qmx-image-size-' + prop );
+				var table = jQuery( el ).closest( 'table' ).find( 'tr[data-qmx-image-size-' + prop + '="' + value + '"]' ).not( tr ).addClass( 'qm-highlight' );
+			}
+
+			function qmx_image_size_highlighter__mouseleave( prop, el ) {
+				jQuery( el ).removeClass( 'qm-highlight' );
+				jQuery( el ).closest( 'table' ).find( 'tr.qm-highlight' ).removeClass( 'qm-highlight' );
+			}
+
+		}
+
+		<?php
+		return ob_get_clean();
+	}
 
 }
 
-?>
+QM_Collectors::add( new QMX_Collector_Image_Sizes );

--- a/image-sizes/qmx-image-sizes-data.php
+++ b/image-sizes/qmx-image-sizes-data.php
@@ -1,31 +1,10 @@
 <?php
-/**
- * Plugin Name: QMX: Image Sizes Data
- * Plugin URI: https://github.com/crstauf/query-monitor-extend/tree/master/image-sizes
- * Description: Query Monitor data for image sizes.
- * Version: 1.0.0
- * Author: Caleb Stauffer
- * Author URI: https://develop.calebstauffer.com
- * Update URI: false
- */
 
 defined( 'WPINC' ) || die();
 
-if ( defined( 'QM_DISABLED' ) && constant( 'QM_DISABLED' ) ) {
-	return;
+class QMX_Data_Image_Sizes extends QM_Data {
+
+	public $sizes = array();
+	public $duplicates = array();
+
 }
-
-if ( constant( 'QMX_DISABLED' ) ) {
-	return;
-}
-
-add_action( 'qmx/load_data/image_sizes', static function () {
-
-	class QMX_Data_Image_Sizes extends QM_Data {
-
-		public $sizes = array();
-		public $duplicates = array();
-
-	}
-
-} );

--- a/paths/qmx-paths-collector.php
+++ b/paths/qmx-paths-collector.php
@@ -1,178 +1,144 @@
 <?php
-/**
- * Plugin Name: QMX: Paths Collector
- * Plugin URI: https://github.com/crstauf/query-monitor-extend/tree/master/paths
- * Description: Query Monitor collector for paths.
- * Version: 1.0.0
- * Author: Caleb Stauffer
- * Author URI: https://develop.calebstauffer.com
- * Update URI: false
- */
 
 defined( 'WPINC' ) || die();
 
-defined( 'QMX_DISABLED' ) || define( 'QMX_DISABLED', false );
-defined( 'QMX_TESTED_WITH_QM' ) || define( 'QMX_TESTED_WITH_QM', '3.13.0' );
+class QMX_Collector_Paths extends QM_DataCollector {
 
-add_action( 'plugin_loaded', 'load_qmx_paths_collector' );
+	public $id = 'paths';
 
-function load_qmx_paths_collector( string $file ) {
-
-	if ( 'query-monitor/query-monitor.php' !== plugin_basename( $file ) )
-		return;
-
-	remove_action( 'plugin_loaded', __FUNCTION__ );
-
-	if ( !class_exists( 'QueryMonitor' ) )
-		return;
-
-	if ( defined( 'QM_DISABLED' ) && constant( 'QM_DISABLED' ) ) {
-		return;
+	public function name() {
+		return __( 'Paths', 'query-monitor-extend' );
 	}
 
-	if ( constant( 'QMX_DISABLED' ) ) {
-		return;
+	public function get_storage(): QM_Data {
+		do_action( 'qmx/load_data/paths' );
+		return new QMX_Data_Paths();
 	}
 
-	class QMX_Collector_Paths extends QM_DataCollector {
+	function process() {
+		if ( did_action( 'qm/cease' ) )
+			return;
 
-		public $id = 'paths';
+		$this->data->paths = apply_filters( 'qmx/collector/paths', array(
+			'ABSPATH' => ABSPATH,
+			'COOKIEPATH' => COOKIEPATH,
+			'SITECOOKIEPATH' => SITECOOKIEPATH,
+			'DOMAIN_CURRENT_SITE' => defined( 'DOMAIN_CURRENT_SITE' ) ? DOMAIN_CURRENT_SITE : 'undefined',
+			'PATH_CURRENT_SITE' => defined( 'PATH_CURRENT_SITE' ) ? PATH_CURRENT_SITE : 'undefined',
+			'WP_SITEURL' => defined( 'WP_SITEURL' ) ? WP_SITEURL : 'undefined',
+			'site_url()' => site_url(),
+			'get_site_url()' => get_site_url(),
+			'network_site_url()' => network_site_url(),
+			'WP_HOME' => defined( 'WP_HOME' ) ? WP_HOME : 'undefined',
+			'home_url()' => home_url(),
+			'get_home_url()' => get_home_url(),
+			'network_home_url()' => network_home_url(),
+			'get_home_path()' => function_exists( 'get_home_path' ) ? get_home_path() : '',
+			'WP_CONTENT_URL' => WP_CONTENT_URL,
+			'WP_CONTENT_DIR' => WP_CONTENT_DIR,
+			'content_url()' => content_url(),
+			'WP_PLUGIN_URL' => WP_PLUGIN_URL,
+			'WP_PLUGIN_DIR' => WP_PLUGIN_DIR,
+			'PLUGINS_COOKIE_PATH' => PLUGINS_COOKIE_PATH,
+			'plugins_url()' => plugins_url(),
+			'plugin_dir_url( __FILE__ )' => plugin_dir_url( __FILE__ ),
+			'plugin_dir_path( __FILE__ )' => plugin_dir_path( __FILE__ ),
+			'plugin_basename( __FILE__ )' => plugin_basename( __FILE__ ),
+			'WPMU_PLUGIN_DIR' => WPMU_PLUGIN_DIR,
+			'WPMU_PLUGIN_URL' => WPMU_PLUGIN_URL,
+			'get_theme_root()' => get_theme_root(),
+			'get_theme_roots()' => get_theme_roots(),
+			'get_theme_root_uri()' => get_theme_root_uri(),
+			'get_template_directory()' => get_template_directory(),
+			'TEMPLATEPATH' => TEMPLATEPATH,
+			'get_template_directory_uri()' => get_template_directory_uri(),
+			'get_stylesheet_uri()' => get_stylesheet_uri(),
+			'get_stylesheet_directory()' => get_stylesheet_directory(),
+			'STYLESHEETPATH' => STYLESHEETPATH,
+			'get_stylesheet_directory_uri()' => get_stylesheet_directory_uri(),
+			'admin_url()' => admin_url(),
+			'get_admin_url()' => get_admin_url(),
+			'network_admin_url()' => network_admin_url(),
+			'ADMIN_COOKIE_PATH' => ADMIN_COOKIE_PATH,
+			'WPINC' => WPINC,
+			'includes_url()' => includes_url(),
+			'WP_LANG_DIR' => WP_LANG_DIR,
+			'BLOGUPLOADDIR' => defined( 'BLOGUPLOADDIR' ) ? BLOGUPLOADDIR : 'undefined',
+			'UPLOADBLOGSDIR' => defined( 'UPLOADBLOGSDIR' ) ? UPLOADBLOGSDIR : 'undefined',
+			'UPLOADS' => defined( 'UPLOADS' ) ? UPLOADS : 'undefined',
+			'wp_upload_dir()' => wp_upload_dir(),
+			'get_theme_file_path()' => get_theme_file_path(),
+			'get_theme_file_uri()' => get_theme_file_uri(),
+		) );
 
-		public function name() {
-			return __( 'Paths', 'query-monitor-extend' );
-		}
+		if ( defined( 'WP_DEBUG_LOG' ) && is_string( WP_DEBUG_LOG ) )
+			$this->data->paths['WP_DEBUG_LOG'] = WP_DEBUG_LOG;
 
-		public function get_storage(): QM_Data {
-			do_action( 'qmx/load_data/paths' );
-			return new QMX_Data_Paths();
-		}
-
-		function process() {
-			if ( did_action( 'qm/cease' ) )
-				return;
-
-			$this->data->paths = apply_filters( 'qmx/collector/paths', array(
-				'ABSPATH' => ABSPATH,
-				'COOKIEPATH' => COOKIEPATH,
-				'SITECOOKIEPATH' => SITECOOKIEPATH,
-				'DOMAIN_CURRENT_SITE' => defined( 'DOMAIN_CURRENT_SITE' ) ? DOMAIN_CURRENT_SITE : 'undefined',
-				'PATH_CURRENT_SITE' => defined( 'PATH_CURRENT_SITE' ) ? PATH_CURRENT_SITE : 'undefined',
-				'WP_SITEURL' => defined( 'WP_SITEURL' ) ? WP_SITEURL : 'undefined',
-				'site_url()' => site_url(),
-				'get_site_url()' => get_site_url(),
-				'network_site_url()' => network_site_url(),
-				'WP_HOME' => defined( 'WP_HOME' ) ? WP_HOME : 'undefined',
-				'home_url()' => home_url(),
-				'get_home_url()' => get_home_url(),
-				'network_home_url()' => network_home_url(),
-				'get_home_path()' => function_exists( 'get_home_path' ) ? get_home_path() : '',
-				'WP_CONTENT_URL' => WP_CONTENT_URL,
-				'WP_CONTENT_DIR' => WP_CONTENT_DIR,
-				'content_url()' => content_url(),
-				'WP_PLUGIN_URL' => WP_PLUGIN_URL,
-				'WP_PLUGIN_DIR' => WP_PLUGIN_DIR,
-				'PLUGINS_COOKIE_PATH' => PLUGINS_COOKIE_PATH,
-				'plugins_url()' => plugins_url(),
-				'plugin_dir_url( __FILE__ )' => plugin_dir_url( __FILE__ ),
-				'plugin_dir_path( __FILE__ )' => plugin_dir_path( __FILE__ ),
-				'plugin_basename( __FILE__ )' => plugin_basename( __FILE__ ),
-				'WPMU_PLUGIN_DIR' => WPMU_PLUGIN_DIR,
-				'WPMU_PLUGIN_URL' => WPMU_PLUGIN_URL,
-				'get_theme_root()' => get_theme_root(),
-				'get_theme_roots()' => get_theme_roots(),
-				'get_theme_root_uri()' => get_theme_root_uri(),
-				'get_template_directory()' => get_template_directory(),
-				'TEMPLATEPATH' => TEMPLATEPATH,
-				'get_template_directory_uri()' => get_template_directory_uri(),
-				'get_stylesheet_uri()' => get_stylesheet_uri(),
-				'get_stylesheet_directory()' => get_stylesheet_directory(),
-				'STYLESHEETPATH' => STYLESHEETPATH,
-				'get_stylesheet_directory_uri()' => get_stylesheet_directory_uri(),
-				'admin_url()' => admin_url(),
-				'get_admin_url()' => get_admin_url(),
-				'network_admin_url()' => network_admin_url(),
-				'ADMIN_COOKIE_PATH' => ADMIN_COOKIE_PATH,
-				'WPINC' => WPINC,
-				'includes_url()' => includes_url(),
-				'WP_LANG_DIR' => WP_LANG_DIR,
-				'BLOGUPLOADDIR' => defined( 'BLOGUPLOADDIR' ) ? BLOGUPLOADDIR : 'undefined',
-				'UPLOADBLOGSDIR' => defined( 'UPLOADBLOGSDIR' ) ? UPLOADBLOGSDIR : 'undefined',
-				'UPLOADS' => defined( 'UPLOADS' ) ? UPLOADS : 'undefined',
-				'wp_upload_dir()' => wp_upload_dir(),
-				'get_theme_file_path()' => get_theme_file_path(),
-				'get_theme_file_uri()' => get_theme_file_uri(),
-			) );
-
-			if ( defined( 'WP_DEBUG_LOG' ) && is_string( WP_DEBUG_LOG ) )
-				$this->data->paths['WP_DEBUG_LOG'] = WP_DEBUG_LOG;
-
-			ksort( $this->data->paths, SORT_FLAG_CASE | SORT_STRING );
-
-		}
-
-		public function get_concerned_filters() {
-			return array(
-				'admin_url',
-				'content_url',
-				'home_url',
-				'includes_url',
-				'plugins_url',
-				'network_admin_url',
-				'network_home_url',
-				'network_site_url',
-				'site_url',
-				'stylesheet_directory',
-				'stylesheet_directory_uri',
-				'stylesheet_uri',
-				'template_directory',
-				'template_directory_uri',
-				'theme_file_path',
-				'theme_file_uri',
-				'theme_root',
-				'theme_root_uri',
-				'upload_dir',
-			);
-		}
-
-		public function get_concerned_constants() {
-			return array(
-				'ABSPATH',
-				'COOKIEPATH',
-				'SITECOOKIEPATH',
-				'DOMAIN_CURRENT_SITE',
-				'PATH_CURRENT_SITE',
-				'WP_SITEURL',
-				'WP_HOME',
-				'WP_CONTENT_URL',
-				'WP_CONTENT_DIR',
-				'WP_PLUGIN_URL',
-				'WP_PLUGIN_DIR',
-				'PLUGINS_COOKIE_PATH',
-				'WPMU_PLUGIN_DIR',
-				'WPMU_PLUGIN_URL',
-				'TEMPLATEPATH',
-				'STYLESHEETPATH',
-				'ADMIN_COOKIE_PATH',
-				'WPINC',
-				'WP_LANG_DIR',
-				'BLOGUPLOADDIR',
-				'UPLOADBLOGSDIR',
-				'UPLOADS',
-			);
-		}
-
-		public function get_concerned_options() {
-			return array(
-				'siteurl',
-				'home',
-			);
-		}
+		ksort( $this->data->paths, SORT_FLAG_CASE | SORT_STRING );
 
 	}
 
-	add_filter( 'qm/collectors', static function ( array $collectors ) : array {
-		$collectors['paths'] = new QMX_Collector_Paths;
-		return $collectors;
-	} );
+	public function get_concerned_filters() {
+		return array(
+			'admin_url',
+			'content_url',
+			'home_url',
+			'includes_url',
+			'plugins_url',
+			'network_admin_url',
+			'network_home_url',
+			'network_site_url',
+			'site_url',
+			'stylesheet_directory',
+			'stylesheet_directory_uri',
+			'stylesheet_uri',
+			'template_directory',
+			'template_directory_uri',
+			'theme_file_path',
+			'theme_file_uri',
+			'theme_root',
+			'theme_root_uri',
+			'upload_dir',
+		);
+	}
+
+	public function get_concerned_constants() {
+		return array(
+			'ABSPATH',
+			'COOKIEPATH',
+			'SITECOOKIEPATH',
+			'DOMAIN_CURRENT_SITE',
+			'PATH_CURRENT_SITE',
+			'WP_SITEURL',
+			'WP_HOME',
+			'WP_CONTENT_URL',
+			'WP_CONTENT_DIR',
+			'WP_PLUGIN_URL',
+			'WP_PLUGIN_DIR',
+			'PLUGINS_COOKIE_PATH',
+			'WPMU_PLUGIN_DIR',
+			'WPMU_PLUGIN_URL',
+			'TEMPLATEPATH',
+			'STYLESHEETPATH',
+			'ADMIN_COOKIE_PATH',
+			'WPINC',
+			'WP_LANG_DIR',
+			'BLOGUPLOADDIR',
+			'UPLOADBLOGSDIR',
+			'UPLOADS',
+		);
+	}
+
+	public function get_concerned_options() {
+		return array(
+			'siteurl',
+			'home',
+		);
+	}
 
 }
+
+add_filter( 'qm/collectors', static function ( array $collectors ) : array {
+	$collectors['paths'] = new QMX_Collector_Paths;
+	return $collectors;
+} );

--- a/paths/qmx-paths-collector.php
+++ b/paths/qmx-paths-collector.php
@@ -11,7 +11,7 @@ class QMX_Collector_Paths extends QM_DataCollector {
 	}
 
 	public function get_storage(): QM_Data {
-		do_action( 'qmx/load_data/paths' );
+		require_once 'qmx-paths-data.php';
 		return new QMX_Data_Paths();
 	}
 

--- a/paths/qmx-paths-data.php
+++ b/paths/qmx-paths-data.php
@@ -1,30 +1,9 @@
 <?php
-/**
- * Plugin Name: QMX: Paths Data
- * Plugin URI: https://github.com/crstauf/query-monitor-extend/tree/master/paths
- * Description: Query Monitor data for paths.
- * Version: 1.0.0
- * Author: Caleb Stauffer
- * Author URI: https://develop.calebstauffer.com
- * Update URI: false
- */
 
 defined( 'WPINC' ) || die();
 
-if ( defined( 'QM_DISABLED' ) && constant( 'QM_DISABLED' ) ) {
-	return;
+class QMX_Data_Paths extends QM_Data {
+
+	public $paths = array();
+
 }
-
-if ( constant( 'QMX_DISABLED' ) ) {
-	return;
-}
-
-add_action( 'qmx/load_data/paths', static function () {
-
-	class QMX_Data_Paths extends QM_Data {
-
-		public $paths = array();
-
-	}
-
-} );

--- a/qmx-conditionals.php
+++ b/qmx-conditionals.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Plugin Name: QMX: Additional Conditionals
- * Plugin URI: https://github.com/crstauf/query-monitor-extend/tree/master/qmx-conditionals.php
- * Description: Additional conditionals for Query Monitor.
- * Version: 1.0.0
- * Author: Caleb Stauffer
- * Author URI: https://develop.calebstauffer.com
- * Update URI: false
- */
+
+defined( 'WPINC' ) || die();
 
 add_filter( 'qm/collect/conditionals', static function( array $conditionals ) : array {
 	$conditionals = array_merge( $conditionals, array(

--- a/query-monitor-extend.php
+++ b/query-monitor-extend.php
@@ -3,18 +3,18 @@
  * Plugin Name: Query Monitor Extend
  * Plugin URI: https://github.com/crstauf/query-monitor-extend
  * Description: Additional panels for Query Monitor by John Blackbourn.
- * Version: 1.4.4
+ * Version: 1.5.0
  * Author: Caleb Stauffer
  * Author URI: https://develop.calebstauffer.com
  * Update URI: false
  *
- * QM tested up to: 3.13.0
+ * QM tested up to: 3.13.1
  */
 
 defined( 'WPINC' ) || die();
 
 defined( 'QMX_DISABLED' ) || define( 'QMX_DISABLED', false );
-defined( 'QMX_TESTED_WITH_QM' ) || define( 'QMX_TESTED_WITH_QM', '3.13.0' );
+defined( 'QMX_TESTED_WITH_QM' ) || define( 'QMX_TESTED_WITH_QM', '3.13.1' );
 
 if ( defined( 'QM_DISABLED' ) && constant( 'QM_DISABLED' ) ) {
 	return;
@@ -83,17 +83,18 @@ $collector_names = array(
 
 $dir = trailingslashit( __DIR__ );
 
+/**
+ * If loading as an mu-plugin, add "query-monitor-extend"
+ * to directory path.
+ */
+if ( trailingslashit( constant( 'WPMU_PLUGIN_DIR' ) ) === $dir ) {
+	$dir .= 'query-monitor-extend/';
+}
+
 # Include all collector and outputters.
 foreach ( $collector_names as $collector_name ) {
 	include_once sprintf( '%1$s%2$s/qmx-%2$s-collector.php', $dir, $collector_name );
 	include_once sprintf( '%1$s%2$s/qmx-%2$s-output.php',    $dir, $collector_name );
-
-	$function_name = sprintf( 'load_qmx_%s_collector', str_replace( '-', '_', $collector_name ) );
-
-	if ( !function_exists( $function_name ) )
-		continue;
-
-	$function_name( 'query-monitor/query-monitor.php' );
 }
 
 # Include additional conditionals.

--- a/query-monitor-extend.php
+++ b/query-monitor-extend.php
@@ -24,6 +24,14 @@ if ( constant( 'QMX_DISABLED' ) ) {
 	return;
 }
 
+// Prevent combo mu-plugin and plugin.
+if ( defined( 'QMX_LOADED' ) ) {
+	trigger_error( sprintf( 'Query Monitor Extend loaded previously: %s', constant( 'QMX_LOADED' ) ), E_USER_NOTICE );
+	return;
+}
+
+define( 'QMX_LOADED', __FILE__ );
+
 /**
  * Filter: plugin_row_meta
  *

--- a/time/qmx-time-collector.php
+++ b/time/qmx-time-collector.php
@@ -1,119 +1,85 @@
 <?php
-/**
- * Plugin Name: QMX: Time Collector
- * Plugin URI: https://github.com/crstauf/query-monitor-extend/tree/master/time
- * Description: Query Monitor collector for time.
- * Version: 1.0.0
- * Author: Caleb Stauffer
- * Author URI: https://develop.calebstauffer.com
- * Update URI: false
- */
 
 defined( 'WPINC' ) || die();
 
-defined( 'QMX_DISABLED' ) || define( 'QMX_DISABLED', false );
-defined( 'QMX_TESTED_WITH_QM' ) || define( 'QMX_TESTED_WITH_QM', '3.13.0' );
+class QMX_Collector_Time extends QM_DataCollector {
 
-add_action( 'plugin_loaded', 'load_qmx_time_collector' );
+	public $id = 'time';
 
-function load_qmx_time_collector( string $file ) {
-
-	if ( 'query-monitor/query-monitor.php' !== plugin_basename( $file ) )
-		return;
-
-	remove_action( 'plugin_loaded', __FUNCTION__ );
-
-	if ( !class_exists( 'QueryMonitor' ) )
-		return;
-
-	if ( defined( 'QM_DISABLED' ) && constant( 'QM_DISABLED' ) ) {
-		return;
+	public function name() {
+		return __( 'Time', 'query-monitor-extend' );
 	}
 
-	if ( constant( 'QMX_DISABLED' ) ) {
-		return;
+	public function get_storage(): QM_Data {
+		do_action( 'qmx/load_data/time' );
+		return new QMX_Data_Time();
 	}
 
-	class QMX_Collector_Time extends QM_DataCollector {
+	function process() {
+		if ( did_action( 'qm/cease' ) )
+			return;
 
-		public $id = 'time';
-
-		public function name() {
-			return __( 'Time', 'query-monitor-extend' );
-		}
-
-		public function get_storage(): QM_Data {
-			do_action( 'qmx/load_data/time' );
-			return new QMX_Data_Time();
-		}
-
-		function process() {
-			if ( did_action( 'qm/cease' ) )
-				return;
-
-			$this->data['functions'] = array(
-				'UTC'       => 'get_utc',
-				'Server'    => 'get_server',
-				'WordPress' => 'get_wp',
-				'Browser'   => 'get_browser',
-			);
-
-		}
-
-		function get_utc() {
-			$datetime = date_create( "now", new DateTimeZone( 'UTC' ) );
-			$datetime->setTimezone( new DateTimeZone( 'UTC' ) );
-			return $datetime->format( 'D, M j, Y H:i:s' );
-		}
-
-		function get_server() {
-			$datetime = date_create( "now", new DateTimeZone( 'UTC' ) );
-
-			if ( !empty( ini_get( 'date.timezone' ) ) )
-				$datetime->setTimezone( new DateTimeZone( ini_get( 'date.timezone' ) ) );
-
-			return $datetime->format( 'D, M j, Y H:i:s T' );
-		}
-
-		function get_server_offset() {
-			$datetime = date_create( "now", new DateTimeZone( 'UTC' ) );
-
-			if ( !empty( ini_get( 'date.timezone' ) ) )
-				$datetime->setTimezone( new DateTimeZone( ini_get( 'date.timezone' ) ) );
-
-			return $datetime->format( 'Z' );
-		}
-
-		function get_server_timezone() {
-			$datetime = date_create( "now", new DateTimeZone( 'UTC' ) );
-
-			if ( !empty( ini_get( 'date.timezone' ) ) )
-				$datetime->setTimezone( new DateTimeZone( ini_get( 'date.timezone' ) ) );
-
-			return $datetime->format( 'T' );
-		}
-
-		function get_wp() {
-			return current_time( 'D, M j, Y H:i:s T' );
-		}
-
-		function get_wp_offset() {
-			return get_option( 'gmt_offset' );
-		}
-
-		function get_wp_timezone() {
-			return current_time( 'T' );
-		}
-
-		function get_browser() {
-			return '-';
-		}
+		$this->data['functions'] = array(
+			'UTC'       => 'get_utc',
+			'Server'    => 'get_server',
+			'WordPress' => 'get_wp',
+			'Browser'   => 'get_browser',
+		);
 
 	}
 
-	add_filter( 'qm/collectors', static function ( array $collectors ) : array {
-		$collectors['time'] = new QMX_Collector_Time;
-		return $collectors;
-	} );
+	function get_utc() {
+		$datetime = date_create( "now", new DateTimeZone( 'UTC' ) );
+		$datetime->setTimezone( new DateTimeZone( 'UTC' ) );
+		return $datetime->format( 'D, M j, Y H:i:s' );
+	}
+
+	function get_server() {
+		$datetime = date_create( "now", new DateTimeZone( 'UTC' ) );
+
+		if ( !empty( ini_get( 'date.timezone' ) ) )
+			$datetime->setTimezone( new DateTimeZone( ini_get( 'date.timezone' ) ) );
+
+		return $datetime->format( 'D, M j, Y H:i:s T' );
+	}
+
+	function get_server_offset() {
+		$datetime = date_create( "now", new DateTimeZone( 'UTC' ) );
+
+		if ( !empty( ini_get( 'date.timezone' ) ) )
+			$datetime->setTimezone( new DateTimeZone( ini_get( 'date.timezone' ) ) );
+
+		return $datetime->format( 'Z' );
+	}
+
+	function get_server_timezone() {
+		$datetime = date_create( "now", new DateTimeZone( 'UTC' ) );
+
+		if ( !empty( ini_get( 'date.timezone' ) ) )
+			$datetime->setTimezone( new DateTimeZone( ini_get( 'date.timezone' ) ) );
+
+		return $datetime->format( 'T' );
+	}
+
+	function get_wp() {
+		return current_time( 'D, M j, Y H:i:s T' );
+	}
+
+	function get_wp_offset() {
+		return get_option( 'gmt_offset' );
+	}
+
+	function get_wp_timezone() {
+		return current_time( 'T' );
+	}
+
+	function get_browser() {
+		return '-';
+	}
 
 }
+
+add_filter( 'qm/collectors', static function ( array $collectors ) : array {
+	$collectors['time'] = new QMX_Collector_Time;
+	return $collectors;
+} );

--- a/time/qmx-time-collector.php
+++ b/time/qmx-time-collector.php
@@ -11,7 +11,7 @@ class QMX_Collector_Time extends QM_DataCollector {
 	}
 
 	public function get_storage(): QM_Data {
-		do_action( 'qmx/load_data/time' );
+		require_once 'qmx-time-data.php';
 		return new QMX_Data_Time();
 	}
 

--- a/time/qmx-time-data.php
+++ b/time/qmx-time-data.php
@@ -1,30 +1,9 @@
 <?php
-/**
- * Plugin Name: QMX: Time Data
- * Plugin URI: https://github.com/crstauf/query-monitor-extend/tree/master/time
- * Description: Query Monitor data for time.
- * Version: 1.0.0
- * Author: Caleb Stauffer
- * Author URI: https://develop.calebstauffer.com
- * Update URI: false
- */
 
 defined( 'WPINC' ) || die();
 
-if ( defined( 'QM_DISABLED' ) && constant( 'QM_DISABLED' ) ) {
-	return;
+class QMX_Data_Time extends QM_Data {
+
+	public $functions = array();
+
 }
-
-if ( constant( 'QMX_DISABLED' ) ) {
-	return;
-}
-
-add_action( 'qmx/load_data/time', static function () {
-
-	class QMX_Data_Time extends QM_Data {
-
-		public $functions = array();
-
-	}
-
-} );

--- a/time/qmx-time-output.php
+++ b/time/qmx-time-output.php
@@ -1,185 +1,129 @@
 <?php
-/**
- * Plugin Name: QMX: Time Output
- * Plugin URI: https://github.com/crstauf/query-monitor-extend/tree/master/time
- * Description: Query Monitor output for time collector.
- * Version: 1.0.0
- * Author: Caleb Stauffer
- * Author URI: https://develop.calebstauffer.com
- * Update URI: false
- */
 
 defined( 'WPINC' ) || die();
 
-add_action( 'shutdown', static function () {
+class QMX_Output_Html_Time extends QM_Output_Html {
 
-	if ( !class_exists( 'QMX_Collector_Time' ) )
-		return;
-
-	if ( ! class_exists( 'QM_Dispatcher_Html' ) || ! QM_Dispatcher_Html::user_can_view() || ! QM_Dispatcher_Html::request_supported() ) {
-		return;
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/panel_menus', array( &$this, 'panel_menu' ), 60 );
 	}
 
-	if ( defined( 'QM_DISABLED' ) && constant( 'QM_DISABLED' ) ) {
-		return;
-	}
+	public function output() {
+		$data = $this->collector->get_data();
+		$wp_offset = get_option( 'gmt_offset' );
 
-	if ( constant( 'QMX_DISABLED' ) ) {
-		return;
-	}
+		echo '<div class="qm qm-non-tabular" id="' . esc_attr( $this->collector->id() ) . '">' .
+			'<div class="qm-boxed">';
 
-	if ( is_admin() ) {
-		if ( ! ( did_action( 'admin_init' ) || did_action( 'admin_footer' ) ) ) {
-			return;
-		}
-	} else {
-		if ( ! ( did_action( 'wp' ) || did_action( 'wp_footer' ) || did_action( 'login_init' ) || did_action( 'gp_head' ) || did_action( 'login_footer' ) || did_action( 'gp_footer' ) ) ) {
-			return;
-		}
-	}
+				foreach ( $data->functions as $label => $function ) {
+					if ( is_callable( array( $this->collector, $function ) ) )
+						echo '<div class="qm-section">' .
+							'<h2>' . esc_html( $label ) . '</h2>' .
+							'<p><code id="qm-time-' . sanitize_title( $label ) . '">' . $this->collector->$function() . '</code></p>' .
+						'</div>';
+				}
 
-	/** Back-compat filter. Please use `qm/dispatch/html` instead */
-	if ( ! apply_filters( 'qm/process', true, is_admin_bar_showing() ) ) {
-		return;
-	}
-
-	$qm = QueryMonitor::init()->plugin_path( 'assets/query-monitor.css' );
-
-	if ( ! file_exists( $qm ) ) {
-		return;
-	}
-
-	$qm_dir = trailingslashit( dirname( dirname( $qm ) ) );
-
-	if ( ! file_exists( $qm_dir . 'output/Html.php' ) )
-		return;
-
-	require_once $qm_dir . 'output/Html.php';
-
-	class QMX_Output_Html_Time extends QM_Output_Html {
-
-		public function __construct( QM_Collector $collector ) {
-			parent::__construct( $collector );
-			add_filter( 'qm/output/panel_menus', array( &$this, 'panel_menu' ), 60 );
-		}
-
-		public function output() {
-			$data = $this->collector->get_data();
-			$wp_offset = get_option( 'gmt_offset' );
-
-			echo '<div class="qm qm-non-tabular" id="' . esc_attr( $this->collector->id() ) . '">' .
-				'<div class="qm-boxed">';
-
-					foreach ( $data->functions as $label => $function ) {
-						if ( is_callable( array( $this->collector, $function ) ) )
-							echo '<div class="qm-section">' .
-								'<h2>' . esc_html( $label ) . '</h2>' .
-								'<p><code id="qm-time-' . sanitize_title( $label ) . '">' . $this->collector->$function() . '</code></p>' .
-							'</div>';
-					}
-
-				echo '</div>';
-				?>
-
-				<script type="text/javascript">
-					( function() {
-						if ( 'function' !== typeof IntersectionObserver )
-							return;
-
-						var qmx_time_interval = 0;
-
-						var observer = new IntersectionObserver( function( entries, observer ) {
-							if ( !entries[0].isIntersecting ) {
-								clearInterval( qmx_time_interval );
-								return;
-							}
-
-							var qmx_time_months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-							var qmx_time_days = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
-
-							var qmx_time_container = document.getElementById( 'qm-time' );
-							var qmx_time_utc = document.getElementById( 'qm-time-utc' );
-							var qmx_time_server = document.getElementById( 'qm-time-server' );
-							var qmx_time_wp = document.getElementById( 'qm-time-wordpress' );
-							var qmx_time_browser = document.getElementById( 'qm-time-browser' );
-
-							if ( qmx_time_container ) {
-								qmx_time_interval = setInterval( function() {
-									var d = new Date();
-									var UTC_string = d.toUTCString();
-									var utc_time = d.getTime() + ( d.getTimezoneOffset() * 60 * 1000 );
-									var server = new Date( utc_time + ( <?php echo esc_js( $this->collector->get_server_offset() ) ?> * 1000 ) );
-									var wp = new Date( utc_time + ( <?php echo esc_js( $this->collector->get_wp_offset() * HOUR_IN_SECONDS ) ?> * 1000 ) );
-
-									qmx_time_utc.innerHTML =
-										qmx_time_days[d.getUTCDay()] + ', '
-										+ qmx_time_months[d.getUTCMonth()] + ' '
-										+ d.getUTCDate() + ', '
-										+ d.getUTCFullYear() + ' '
-										+ ( 10 > d.getUTCHours() ? '0' : '' ) + d.getUTCHours()
-										+ ':' + ( 10 > d.getUTCMinutes() ? '0' : '' ) + d.getUTCMinutes()
-										+ ':' + ( 10 > d.getUTCSeconds() ? '0' : '' ) + d.getUTCSeconds();
-
-									qmx_time_server.innerHTML =
-										qmx_time_days[server.getDay()] + ', '
-										+ qmx_time_months[server.getMonth()] + ' '
-										+ server.getDate() + ', '
-										+ server.getFullYear() + ' '
-										+ ( 10 > server.getHours() ? '0' : '' ) + server.getHours()
-										+ ':' + ( 10 > server.getMinutes() ? '0' : '' ) + server.getMinutes()
-										+ ':' + ( 10 > server.getSeconds() ? '0' : '' ) + server.getSeconds()
-										+ ' <?php echo esc_js( $this->collector->get_server_timezone() ) ?>';
-
-									qmx_time_wp.innerHTML =
-										qmx_time_days[wp.getDay()] + ', '
-										+ qmx_time_months[wp.getMonth()] + ' '
-										+ wp.getDate() + ', '
-										+ wp.getFullYear() + ' '
-										+ ( 10 > wp.getHours() ? '0' : '' ) + wp.getHours()
-										+ ':' + ( 10 > wp.getMinutes() ? '0' : '' ) + wp.getMinutes()
-										+ ':' + ( 10 > wp.getSeconds() ? '0' : '' ) + wp.getSeconds()
-										+ ' <?php echo esc_js( $this->collector->get_wp_timezone() ) ?>';
-
-									qmx_time_browser.innerHTML =
-										qmx_time_days[d.getDay()] + ', '
-										+ qmx_time_months[d.getMonth()] + ' '
-										+ d.getDate() + ', '
-										+ d.getFullYear() + ' '
-										+ ( 10 > d.getHours() ? '0' : '' ) + d.getHours()
-										+ ':' + ( 10 > d.getMinutes() ? '0' : '' ) + d.getMinutes()
-										+ ':' + ( 10 > d.getSeconds() ? '0' : '' ) + d.getSeconds();
-								}, 1000 );
-							}
-						} );
-
-						observer.observe( document.getElementById( 'qm-time' ) );
-
-					} () );
-				</script>
-
-				<?php
 			echo '</div>';
+			?>
 
-		}
+			<script type="text/javascript">
+				( function() {
+					if ( 'function' !== typeof IntersectionObserver )
+						return;
 
-		public function panel_menu( array $menu ) {
+					var qmx_time_interval = 0;
 
-			$menu['time'] = $this->menu( array(
-				'title' => esc_html__( 'Time', 'query-monitor-extend' ),
-				'id'    => 'query-monitor-extend-time',
-			) );
+					var observer = new IntersectionObserver( function( entries, observer ) {
+						if ( !entries[0].isIntersecting ) {
+							clearInterval( qmx_time_interval );
+							return;
+						}
 
-			return $menu;
+						var qmx_time_months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+						var qmx_time_days = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
 
-		}
+						var qmx_time_container = document.getElementById( 'qm-time' );
+						var qmx_time_utc = document.getElementById( 'qm-time-utc' );
+						var qmx_time_server = document.getElementById( 'qm-time-server' );
+						var qmx_time_wp = document.getElementById( 'qm-time-wordpress' );
+						var qmx_time_browser = document.getElementById( 'qm-time-browser' );
+
+						if ( qmx_time_container ) {
+							qmx_time_interval = setInterval( function() {
+								var d = new Date();
+								var UTC_string = d.toUTCString();
+								var utc_time = d.getTime() + ( d.getTimezoneOffset() * 60 * 1000 );
+								var server = new Date( utc_time + ( <?php echo esc_js( $this->collector->get_server_offset() ) ?> * 1000 ) );
+								var wp = new Date( utc_time + ( <?php echo esc_js( $this->collector->get_wp_offset() * HOUR_IN_SECONDS ) ?> * 1000 ) );
+
+								qmx_time_utc.innerHTML =
+									qmx_time_days[d.getUTCDay()] + ', '
+									+ qmx_time_months[d.getUTCMonth()] + ' '
+									+ d.getUTCDate() + ', '
+									+ d.getUTCFullYear() + ' '
+									+ ( 10 > d.getUTCHours() ? '0' : '' ) + d.getUTCHours()
+									+ ':' + ( 10 > d.getUTCMinutes() ? '0' : '' ) + d.getUTCMinutes()
+									+ ':' + ( 10 > d.getUTCSeconds() ? '0' : '' ) + d.getUTCSeconds();
+
+								qmx_time_server.innerHTML =
+									qmx_time_days[server.getDay()] + ', '
+									+ qmx_time_months[server.getMonth()] + ' '
+									+ server.getDate() + ', '
+									+ server.getFullYear() + ' '
+									+ ( 10 > server.getHours() ? '0' : '' ) + server.getHours()
+									+ ':' + ( 10 > server.getMinutes() ? '0' : '' ) + server.getMinutes()
+									+ ':' + ( 10 > server.getSeconds() ? '0' : '' ) + server.getSeconds()
+									+ ' <?php echo esc_js( $this->collector->get_server_timezone() ) ?>';
+
+								qmx_time_wp.innerHTML =
+									qmx_time_days[wp.getDay()] + ', '
+									+ qmx_time_months[wp.getMonth()] + ' '
+									+ wp.getDate() + ', '
+									+ wp.getFullYear() + ' '
+									+ ( 10 > wp.getHours() ? '0' : '' ) + wp.getHours()
+									+ ':' + ( 10 > wp.getMinutes() ? '0' : '' ) + wp.getMinutes()
+									+ ':' + ( 10 > wp.getSeconds() ? '0' : '' ) + wp.getSeconds()
+									+ ' <?php echo esc_js( $this->collector->get_wp_timezone() ) ?>';
+
+								qmx_time_browser.innerHTML =
+									qmx_time_days[d.getDay()] + ', '
+									+ qmx_time_months[d.getMonth()] + ' '
+									+ d.getDate() + ', '
+									+ d.getFullYear() + ' '
+									+ ( 10 > d.getHours() ? '0' : '' ) + d.getHours()
+									+ ':' + ( 10 > d.getMinutes() ? '0' : '' ) + d.getMinutes()
+									+ ':' + ( 10 > d.getSeconds() ? '0' : '' ) + d.getSeconds();
+							}, 1000 );
+						}
+					} );
+
+					observer.observe( document.getElementById( 'qm-time' ) );
+
+				} () );
+			</script>
+
+			<?php
+		echo '</div>';
 
 	}
 
-	add_filter( 'qm/outputter/html', static function ( array $output ) : array {
-		if ( $collector = QM_Collectors::get( 'time' ) )
-			$output['time'] = new QMX_Output_Html_Time( $collector );
+	public function panel_menu( array $menu ) {
 
-		return $output;
-	}, 70 );
+		$menu['time'] = $this->menu( array(
+			'title' => esc_html__( 'Time', 'query-monitor-extend' ),
+			'id'    => 'query-monitor-extend-time',
+		) );
 
-}, 9 );
+		return $menu;
+
+	}
+
+}
+
+add_filter( 'qm/outputter/html', static function ( array $output ) : array {
+	if ( $collector = QM_Collectors::get( 'time' ) )
+		$output['time'] = new QMX_Output_Html_Time( $collector );
+
+	return $output;
+}, 70 );


### PR DESCRIPTION
The structure introduced in [1.3](https://github.com/crstauf/query-monitor-extend/releases/tag/version%2F1.3) was great, but introduced several issues and complications as well, so I'm going back. The plan is to automate some release packages: one for a standard plugin, the other for an mu-plugin.