### PR TITLE
Set composer package type to wordpress-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "crstauf/query-monitor-extend",
   "description": "Query Monitor Extend",
+  "type": "wordpress-plugin",
   "require-dev": {
     "automattic/vipwpcs": "^3.0",
     "szepeviktor/phpstan-wordpress": "^1.1",


### PR DESCRIPTION
This is standard for WP plugins installed via composer. It allows installation in the correct plugins directory with the following changes to user's project `composer.json`:
```json
"extra": {
        "installer-paths": {
            "wp-content/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
            "wp-content/plugins/{$name}/": ["type:wordpress-plugin"]
        }
    }
```

The specific path might vary from project to project. `roots/bedrock` might use `web/app/plugins/{$name}/` instead