### PR TITLE
Add timing functions for hooks

### DIFF
--- a/qmx-time-hooks.php
+++ b/qmx-time-hooks.php
@@ -45,7 +45,14 @@ function qmx_stop() : void {
 	qmx_time_hooks( 'stop' );
 }
 
-add_action( 'init', 'qmx_start', 0 );
-add_action( 'init', 'qmx_lap', 9 );
-add_action( 'init', 'qmx_lap', 11 );
-add_action( 'init', 'qmx_stop', 25 );
+/**
+ * @return void
+ */
+function qmx_auto() : void {
+	if ( ! doing_action() ) {
+		return;
+	}
+
+	qmx_time_hooks( 'start' );
+	add_action( current_action(), 'qmx_stop', PHP_INT_MAX );
+}

--- a/qmx-time-hooks.php
+++ b/qmx-time-hooks.php
@@ -1,0 +1,46 @@
+<?php
+
+defined( 'WPINC' ) || die();
+
+function qmx_time_hooks( string $start_lap_stop ) : void {
+	if ( ! doing_action() ) {
+		return;
+	}
+
+	if ( ! in_array( $start_lap_stop, array( 'start', 'lap', 'stop' ) ) ) {
+		return;
+	}
+
+	global $wp_filter;
+
+	$label    = 'Action: ' . current_action();
+	$action   = sprintf( 'qm/%s', $start_lap_stop );
+	$priority = $wp_filter[ current_action() ]->current_priority();
+
+	do_action( $action, $label );
+}
+
+/**
+ * @return void
+ */
+function qmx_start() : void {
+	qmx_time_hooks( 'start' );
+}
+
+/**
+ * @return void
+ */
+function qmx_lap() : void {
+	qmx_time_hooks( 'lap' );
+}
+
+/**
+ * @return void
+ */
+function qmx_stop() : void {
+	qmx_time_hooks( 'stop' );
+}
+
+add_action( 'init', 'qmx_start', 0 );
+add_action( 'init', 'qmx_lap', 5 );
+add_action( 'init', 'qmx_stop', 50 );

--- a/qmx-time-hooks.php
+++ b/qmx-time-hooks.php
@@ -13,11 +13,15 @@ function qmx_time_hooks( string $start_lap_stop ) : void {
 
 	global $wp_filter;
 
-	$label    = 'Action: ' . current_action();
+	$label    = current_action();
 	$action   = sprintf( 'qm/%s', $start_lap_stop );
-	$priority = $wp_filter[ current_action() ]->current_priority();
+	$priority = '';
 
-	do_action( $action, $label );
+	if ( 'lap' === $start_lap_stop ) {
+		$priority = $wp_filter[ current_action() ]->current_priority();
+	}
+
+	do_action( $action, $label, $priority );
 }
 
 /**
@@ -42,5 +46,6 @@ function qmx_stop() : void {
 }
 
 add_action( 'init', 'qmx_start', 0 );
-add_action( 'init', 'qmx_lap', 5 );
-add_action( 'init', 'qmx_stop', 50 );
+add_action( 'init', 'qmx_lap', 9 );
+add_action( 'init', 'qmx_lap', 11 );
+add_action( 'init', 'qmx_stop', 25 );

--- a/query-monitor-extend.php
+++ b/query-monitor-extend.php
@@ -121,5 +121,8 @@ foreach ( $collector_names as $collector_name ) {
 	}
 }
 
+# Include hook timing feature.
+include_once $dir . 'qmx-time-hooks.php';
+
 # Include additional conditionals.
 include_once $dir . 'qmx-conditionals.php';


### PR DESCRIPTION
Been waiting for QM to adopt this functionality since 2019 (johnbillion/query-monitor#309, johnbillion/query-monitor#407), might as well implement here until it shows up there.

```php
add_action( 'init', 'qmx_start', 0 );
add_action( 'init', 'qmx_lap', 5 );
add_action( 'init', 'qmx_stop' );
```

```php
// Timer runs from `0` to `PHP_INT_MAX` priorites.
add_action( 'template_redirect', 'qmx_auto', 0 );
```