### PR TITLE
Fix editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,12 @@
+root = true
+
 [*]
-charset = utf-8
-end_of_line = lf
 indent_style = tab
+indent_size = 4
+end_of_line = lf
+charset = utf-8
 trim_trailing_whitespace = true
+insert_final_newline = true
 
 [*.{yml,json,svg,xml}]
 indent_style = space


### PR DESCRIPTION
- add [missing keys](https://EditorConfig.org)
- make GitHub display 4-space wide TAB characters