### PR TITLE
Support the new structure of PHP errors in Query Monitor 4

### DIFF
--- a/files/qmx-files-collector.php
+++ b/files/qmx-files-collector.php
@@ -31,9 +31,17 @@ class QMX_Collector_Files extends QM_DataCollector {
 			$php_errors = $collector->get_data();
 
 			if ( ! empty( $php_errors['errors'] ) ) {
-				foreach ( $php_errors['errors'] as $type => $errors ) {
-					foreach ( $errors as $error ) {
-						$files_with_errors[ $error['file'] ] = 1;
+				foreach ( $php_errors['errors'] as $key => $value ) {
+					if ( is_object( $value ) && isset( $value->callsite->file ) ) {
+						// New format: flat array of error objects with callsite
+						$files_with_errors[ $value->callsite->file ] = 1;
+					} elseif ( is_array( $value ) ) {
+						// Old format: nested array grouped by type
+						foreach ( $value as $error ) {
+							if ( isset( $error['file'] ) ) {
+								$files_with_errors[ $error['file'] ] = 1;
+							}
+						}
 					}
 				}
 			}

--- a/files/qmx-files-collector.php
+++ b/files/qmx-files-collector.php
@@ -33,10 +33,10 @@ class QMX_Collector_Files extends QM_DataCollector {
 			if ( ! empty( $php_errors['errors'] ) ) {
 				foreach ( $php_errors['errors'] as $key => $value ) {
 					if ( is_object( $value ) && isset( $value->callsite->file ) ) {
-						// New format: flat array of error objects with callsite
+						// QM >= v4: flat array of error objects with callsite
 						$files_with_errors[ $value->callsite->file ] = 1;
 					} elseif ( is_array( $value ) ) {
-						// Old format: nested array grouped by type
+						// QM < v4: nested array grouped by type
 						foreach ( $value as $error ) {
 							if ( isset( $error['file'] ) ) {
 								$files_with_errors[ $error['file'] ] = 1;


### PR DESCRIPTION
I've just released the first alpha of Query Monitor 4 which switches from server-side rendered panels to client-side rendering with Preact: https://github.com/johnbillion/query-monitor/releases.

I've worked hard to provide back-compat for existing server-side rendered panels, including those in QMX, however one change I have had to make is to the structure of the data for PHP errors. This requires a small change to QMX to account for the updated structure and avoid (ironically) a PHP error.

This change is compatible with the current stable QM and QM 4+.