### PR TITLE
Compatibility with Query Monitor 4: fix ACF collector and sub-panels

### DIFF
--- a/acf/qmx-acf-collector.php
+++ b/acf/qmx-acf-collector.php
@@ -246,11 +246,9 @@ class QMX_Collector_ACF extends QM_DataCollector {
 	}
 
 	public function get_concerned_actions() {
-		$actions = array(
+		return array(
 			'acf/init',
 		);
-
-		return $actions;
 	}
 
 	public function get_concerned_filters() {

--- a/acf/qmx-acf-collector.php
+++ b/acf/qmx-acf-collector.php
@@ -123,27 +123,43 @@ class QMX_Collector_ACF extends QM_DataCollector {
 
 		$trace = new QM_Backtrace( $args );
 
+		$filtered_trace = $trace->get_filtered_trace();
+		$caller_frame   = $filtered_trace[0] ?? null;
+		$caller_site    = $filtered_trace[1] ?? $caller_frame;
+
 		if ( false === $full_stack_trace ) {
-			foreach ( $trace->get_trace() as $frame ) {
-				if (
-					in_array( $frame['function'], static::get_start_trace_functions() )
-					&& false === stripos( $frame['file'], constant( 'ACF_PATH' ) )
-				) {
-					break;
+			$start_trace_functions = static::get_start_trace_functions();
+			$acf_path              = (string) constant( 'ACF_PATH' );
+
+			foreach ( $filtered_trace as $index => $frame ) {
+				if ( ! in_array( $frame->id, $start_trace_functions, true ) ) {
+					continue;
 				}
 
-				if ( ! empty( $trace->get_trace()[1] ) ) {
-					$trace->ignore( 1 );
+				// QM 4.x shifts file/line up by one frame, so the frame
+				// below this one is where this function was called from.
+				$site = $filtered_trace[ $index + 1 ] ?? $frame;
+
+				if ( ! empty( $site->file ) && false === stripos( (string) $site->file, $acf_path ) ) {
+					$caller_frame = $frame;
+					$caller_site  = $site;
+					break;
 				}
 			}
 		}
+
+		$caller = array(
+			'function' => $caller_frame ? $caller_frame->id : '',
+			'file'     => $caller_site ? $caller_site->file : '',
+			'line'     => $caller_site ? $caller_site->line : 0,
+		);
 
 		$row = array(
 			'field'     => $field,
 			'post_id'   => acf_get_valid_post_id( $post_id ),
 			'trace'     => $trace,
 			'exists'    => ! empty( $field['key'] ),
-			'caller'    => $trace->get_trace()[0],
+			'caller'    => $caller,
 			'group'     => null,
 			'hash'      => null,
 			'duplicate' => false,

--- a/acf/qmx-acf-output-loaded-field-groups.php
+++ b/acf/qmx-acf-output-loaded-field-groups.php
@@ -1,0 +1,158 @@
+<?php declare(strict_types=1);
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Sub-panel outputter for the Loaded Field Groups view (admin only).
+ *
+ * @property-read QMX_Collector_ACF $collector
+ */
+class QMX_Output_Html_ACF_LoadedFieldGroups extends QM_Output_Html {
+
+	public function name() {
+		return __( 'Advanced Custom Fields: Loaded Field Groups', 'query-monitor-extend' );
+	}
+
+	public function output() : void {
+		/** @var QMX_Data_ACF */
+		$data = $this->collector->get_data();
+		$id   = 'qm-acf-loaded_field_groups';
+		$name = $this->name();
+
+		printf(
+			'<div class="qm qm-concerns" id="%1$s" role="tabpanel" aria-labelledby="%1$s-caption" tabindex="-1">',
+			esc_attr( $id )
+		);
+
+		echo '<table class="qm-sortable">';
+
+		printf(
+			'<caption><h2 id="%1$s-caption">%2$s</h2></caption>',
+			esc_attr( $id ),
+			esc_html( $name )
+		);
+
+		echo '<thead>';
+		echo '<tr>';
+		echo '<th scope="col">' . esc_html__( 'Field Group', 'query-monitor-extend' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Key', 'query-monitor-extend' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Rules', 'query-monitor-extend' ) . '</th>';
+		echo '</tr>';
+		echo '</thead>';
+
+		echo '<tbody>';
+
+		$row_num = 1;
+
+		foreach ( $data->loaded_field_groups as $row ) {
+			$class = '';
+
+			if ( 1 === ( $row_num % 2 ) ) {
+				$class = ' class="qm-odd"';
+			}
+
+			echo '<tr' . $class . '>';
+
+			echo '<td class="qm-ltr qm-nowrap">';
+			$this->output_column_title( $row );
+			echo '</td>';
+
+			echo '<td class="qm-ltr">';
+			$this->output_column_key( $row );
+			echo '</td>';
+
+			echo '<td class="qm-ltr qm-nowrap qm-has-inner">';
+			$this->output_column_rules( $row );
+			echo '</td>';
+
+			echo '</tr>';
+
+			$row_num++;
+		}
+
+		echo '</tbody>';
+
+		echo '<tfoot>';
+		echo '<tr>';
+		printf( '<td colspan="3">Total: %d</td>', count( $data->loaded_field_groups ) );
+		echo '</tr>';
+		echo '</tfoot>';
+
+		echo '</table>';
+		echo '</div>';
+	}
+
+	/**
+	 * @param array<string, mixed> $row
+	 */
+	protected function output_column_title( array $row ) : void {
+		$title = $row['title'];
+
+		if ( empty( $title ) ) {
+			return;
+		}
+
+		if ( empty( $row['id'] ) || ! current_user_can( 'edit_post', $row['id'] ) ) {
+			echo esc_html( $title );
+			return;
+		}
+
+		$url = add_query_arg( array(
+			'post'   => $row['id'],
+			'action' => 'edit',
+		), admin_url( 'post.php' ) );
+
+		printf(
+			'<a href="%1$s" class="qm-edit-link">%2$s%3$s</a>',
+			esc_url( $url ),
+			esc_html( $title ),
+			QueryMonitor::icon( 'edit' )
+		);
+	}
+
+	/**
+	 * @param array<string, mixed> $row
+	 */
+	protected function output_column_key( array $row ) : void {
+		/** @var QMX_Data_ACF */
+		$data  = $this->collector->get_data();
+		$group = $row['group'];
+
+		if ( empty( $group ) ) {
+			return;
+		}
+
+		if (
+			! function_exists( 'acf_is_local_field_group' )
+			|| ! acf_is_local_field_group( $group )
+			|| ! array_key_exists( $group, $data->local_json['groups'] )
+		) {
+			echo esc_html( $group );
+			return;
+		}
+
+		$filepath = $data->local_json['groups'][ $group ]['local_file'];
+
+		if ( ! file_exists( $filepath ) ) {
+			echo esc_html( $group );
+			return;
+		}
+
+		echo QM_Output_Html::output_filename( $group, $filepath );
+	}
+
+	/**
+	 * @param array<string, mixed> $row
+	 */
+	protected function output_column_rules( array $row ) : void {
+		$rules = $row['rules'];
+
+		if ( empty( $rules ) ) {
+			return;
+		}
+
+		echo '<pre>';
+		print_r( $rules );
+		echo '</pre>';
+	}
+}

--- a/acf/qmx-acf-output-local-json.php
+++ b/acf/qmx-acf-output-local-json.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types=1);
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Sub-panel outputter for the Local JSON view.
+ *
+ * @property-read QMX_Collector_ACF $collector
+ */
+class QMX_Output_Html_ACF_LocalJSON extends QM_Output_Html {
+
+	public function name() {
+		return __( 'Advanced Custom Fields: Local JSON', 'query-monitor-extend' );
+	}
+
+	public function output() : void {
+		/** @var QMX_Data_ACF */
+		$data = $this->collector->get_data();
+		$id   = 'qm-acf-local_json';
+		$name = $this->name();
+
+		printf(
+			'<div class="qm qm-concerns" id="%1$s" role="tabpanel" aria-labelledby="%1$s-caption" tabindex="-1">',
+			esc_attr( $id )
+		);
+
+		echo '<table class="qm-sortable">';
+
+		printf(
+			'<caption><h2 id="%1$s-caption">%2$s<br />%3$s</h2></caption>',
+			esc_attr( $id ),
+			esc_html( $name ),
+			'<a href="https://www.advancedcustomfields.com/resources/local-json/" rel="noopener noreferrer" class="qm-external-link">Documentation</a>'
+		);
+
+		echo '<thead>';
+		echo '<tr>';
+		echo '<th scope="col">Action</th>';
+		echo '<th scope="col">Hook</th>';
+		echo '<th scope="col" colspan="2">Paths</th>';
+		echo '</tr>';
+		echo '</thead>';
+
+		echo '<tbody>';
+
+		if ( ! empty( $data->local_json['save'] ) ) {
+			$directory = apply_filters( 'acf/settings/save_json', $data->local_json['save'] );
+			echo '<tr>';
+			echo '<th scope="row">Save</th>';
+			echo '<td><code>acf/settings/save_json</code></td>';
+			echo '<td colspan="2">' . QM_Output_Html::output_filename( self::remove_abspath( $directory ), $directory ) . '</td>';
+			echo '</tr>';
+		}
+
+		if ( ! empty( $data->local_json['load'] ) ) {
+			$i = 0;
+
+			foreach ( $data->local_json['load'] as $path ) {
+				echo '<tr>';
+
+				if ( 0 === $i ) {
+					echo '<th scope="row" rowspan="' . esc_attr( (string) count( $data->local_json['load'] ) ) . '">Load</th>';
+					echo '<td rowspan="' . esc_attr( (string) count( $data->local_json['load'] ) ) . '"><code>acf/settings/load_json</code></td>';
+				}
+
+				echo '<td class="qm-num">' . esc_html( (string) $i ) . '</td>';
+				echo '<td>' . QM_Output_Html::output_filename( self::remove_abspath( $path ), $path ) . '</td>';
+
+				echo '</tr>';
+
+				$i++;
+			}
+		}
+
+		echo '</tbody>';
+		echo '</table>';
+
+		$this->output_field_groups();
+
+		echo '</div>';
+	}
+
+	protected function output_field_groups() : void {
+		$data = $this->collector->get_data();
+
+		if ( empty( $data->local_json['groups'] ) ) {
+			echo '<section class="qm-non-tabular"><div class="qm-notice"><p>No local JSON field groups found.</p></div></section>';
+			return;
+		}
+
+		$groups = array();
+
+		foreach ( $data->local_json['groups'] as $group ) {
+			$groups[ $group['title'] ] = $group;
+		}
+
+		ksort( $groups, SORT_NATURAL );
+
+		echo '<table>';
+		echo '<caption><h2>Field Groups</caption>';
+		echo '<thead>';
+		echo '<tr>';
+		echo '<th scope="col">Title</th>';
+		echo '<th scope="col">Key</th>';
+		echo '<th scope="col">File</th>';
+		echo '</tr>';
+		echo '</thead>';
+		echo '<tbody>';
+
+		foreach ( $groups as $group ) {
+			printf(
+				'<tr><th scope="row">%s</th><td>%s</td><td>%s</td></tr>',
+				esc_html( $group['title'] ),
+				esc_html( $group['key'] ),
+				QM_Output_Html::output_filename( self::remove_abspath( $group['local_file'] ), $group['local_file'] )
+			);
+		}
+
+		echo '</tbody>';
+		printf( '<tfoot><tr><td colspan="3">Total: <span class="qm-items-number">%d</span></td></tr></tfoot>', count( $data->local_json['groups'] ) );
+		echo '</table>';
+	}
+
+	public static function remove_abspath( string $path ) : string {
+		return str_replace( ABSPATH, '', $path );
+	}
+}

--- a/acf/qmx-acf-output.php
+++ b/acf/qmx-acf-output.php
@@ -30,16 +30,7 @@ class QMX_Output_Html_ACF extends QM_Output_Html {
 	}
 
 	public function output() : void {
-		/** @var QMX_Data_ACF */
-		$data = $this->collector->get_data();
-
 		$this->output_fields_table();
-		$this->output_local_json();
-		$this->output_concerns();
-
-		if ( is_admin() ) {
-			$this->output_field_groups_table();
-		}
 	}
 
 	protected function output_fields_table() : void {
@@ -174,90 +165,6 @@ class QMX_Output_Html_ACF extends QM_Output_Html {
 		echo '</div>';
 	}
 
-	protected function output_field_groups_table() : void {
-		/** @var QMX_Data_ACF */
-		$data = $this->collector->get_data();
-		$id   = 'qm-acf-loaded_field_groups';
-		$name = 'Advanced Custom Fields: Loaded Field Groups';
-
-		printf(
-			'<div class="qm qm-concerns" id="%1$s" role="tabpanel" aria-labelledby="%1$s-caption" tabindex="-1">',
-			esc_attr( $id )
-		);
-
-		echo '<table class="qm-sortable">';
-
-		printf(
-			'<caption><h2 id="%1$s-caption">%2$s</h2></caption>',
-			esc_attr( $id ),
-			esc_html( $name )
-		);
-
-		echo '<thead>';
-
-		echo '<tr>';
-
-		echo '<th scope="col">';
-		echo esc_html__( 'Field Group', 'query-monitor-extend' );
-		echo '</th>';
-
-		echo '<th scope="col">';
-		echo esc_html__( 'Key', 'query-monitor-extend' );
-		echo '</th>';
-
-		echo '<th scope="col">';
-		echo esc_html__( 'Rules', 'query-monitor-extend' );
-		echo '</th>';
-
-		echo '</tr>';
-
-		echo '</thead>';
-
-		echo '<tbody>';
-
-		$row_num = 1;
-
-		foreach ( $data->loaded_field_groups as $row ) {
-			$class = '';
-
-			if ( 1 === ( $row_num % 2 ) ) {
-				$class = ' class="qm-odd"';
-			}
-
-			echo '<tr' . $class . '>';
-
-			# Field group name
-			echo '<td class="qm-ltr qm-nowrap">';
-			$this->output_column_field_group_title( $row );
-			echo '</td>';
-
-			# Field group key
-			echo '<td class="qm-ltr">';
-			$this->output_column_field_group_key( $row );
-			echo '</td>';
-
-			# Field group rules
-			echo '<td class="qm-ltr qm-nowrap qm-has-inner">';
-			$this->output_column_field_group_rules( $row );
-			echo '</td>';
-
-			echo '</tr>';
-
-			$row_num++;
-		}
-
-		echo '</tbody>';
-
-		echo '<tfoot>';
-		echo '<tr>';
-		printf( '<td colspan="3">Total: %d</td>', count( $data->loaded_field_groups ) );
-		echo '</tr>';
-		echo '</tfoot>';
-
-		echo '</table>';
-		echo '</div>';
-	}
-
 	/**
 	 * @param array<string, mixed> $row
 	 */
@@ -293,65 +200,6 @@ class QMX_Output_Html_ACF extends QM_Output_Html {
 	/**
 	 * @param array<string, mixed> $row
 	 */
-	protected function output_column_field_group_title( array $row ) : void {
-		$title = $row['title'];
-
-		if ( empty( $title ) ) {
-			return;
-		}
-
-		if ( empty( $row['id'] ) || ! current_user_can( 'edit_post', $row['id'] ) ) {
-			echo esc_html( $title );
-			return;
-		}
-
-		$url = add_query_arg( array(
-			'post'   => $row['id'],
-			'action' => 'edit',
-		), admin_url( 'post.php' ) );
-
-		printf(
-			'<a href="%1$s" class="qm-edit-link">%2$s%3$s</a>',
-			esc_url( $url ),
-			esc_html( $title ),
-			QueryMonitor::icon( 'edit' )
-		);
-	}
-
-	/**
-	 * @param array<string, mixed> $row
-	 */
-	protected function output_column_field_group_key( array $row ) : void {
-		/** @var QMX_Data_ACF */
-		$data  = $this->collector->get_data();
-		$group = $row['group'];
-
-		if ( empty( $group ) ) {
-			return;
-		}
-
-		if (
-			! function_exists( 'acf_is_local_field_group' )
-			|| ! acf_is_local_field_group( $group )
-			|| ! array_key_exists( $group, $data->local_json['groups'] )
-		) {
-			echo esc_html( $group );
-			return;
-		}
-
-		$filepath = $data->local_json['groups'][ $group ]['local_file'];
-
-		if ( ! file_exists( $filepath ) ) {
-			echo esc_html( $group );
-			return;
-		}
-
-		echo QM_Output_Html::output_filename( $group, $filepath );
-	}
-
-	/**
-	 * @param array<string, mixed> $row
-	 */
 	protected function output_column_field_group( array $row ) : void {
 		$group = $row['group'];
 
@@ -375,21 +223,6 @@ class QMX_Output_Html_ACF extends QM_Output_Html {
 			esc_html( $group['title'] ),
 			QueryMonitor::icon( 'edit' )
 		);
-	}
-
-	/**
-	 * @param array<string, mixed> $row
-	 */
-	protected function output_column_field_group_rules( array $row ) : void {
-		$rules = $row['rules'];
-
-		if ( empty( $rules ) ) {
-			return;
-		}
-
-		echo '<pre>';
-		print_r( $rules );
-		echo '</pre>';
 	}
 
 	/**
@@ -426,117 +259,6 @@ class QMX_Output_Html_ACF extends QM_Output_Html {
 		echo '</ol>';
 	}
 
-	protected function output_local_json() : void {
-		$id   = 'qm-acf-local_json';
-		$name = 'Advanced Custom Fields: Local JSON';
-		$data = $this->collector->get_data();
-
-		printf(
-			'<div class="qm qm-concerns" id="%1$s" role="tabpanel" aria-labelledby="%1$s-caption" tabindex="-1">',
-			esc_attr( $id )
-		);
-
-		echo '<table class="qm-sortable">';
-
-		printf(
-			'<caption><h2 id="%1$s-caption">%2$s<br />%3$s</h2></caption>',
-			esc_attr( $id ),
-			esc_html( $name ),
-			'<a href="https://www.advancedcustomfields.com/resources/local-json/" rel="noopener noreferrer" class="qm-external-link">Documentation</a>'
-		);
-
-		echo '<thead>';
-		echo '<tr>';
-		echo '<th scope="col">Action</th>';
-		echo '<th scope="col">Hook</th>';
-		echo '<th scope="col" colspan="2">Paths</th>';
-		echo '</tr>';
-		echo '</thead>';
-
-		echo '<tbody>';
-
-		if ( ! empty( $data->local_json['save'] ) ) {
-			$directory = apply_filters( 'acf/settings/save_json', $data->local_json['save'] );
-			echo '<tr>';
-			echo '<th scope="row">Save</th>';
-			echo '<td><code>acf/settings/save_json</code></td>';
-			echo '<td colspan="2">' . QM_Output_Html::output_filename( $this->remove_abspath( $directory ), $directory ) . '</td>';
-			echo '</tr>';
-		}
-
-		if ( ! empty( $data->local_json['load'] ) ) {
-			$i = 0;
-
-			foreach ( $data->local_json['load'] as $path ) {
-				echo '<tr>';
-
-				if ( 0 === $i ) {
-					echo '<th scope="row" rowspan="' . esc_attr( (string) count( $data->local_json['load'] ) ) . '">Load</th>';
-					echo '<td rowspan="' . esc_attr( (string) count( $data->local_json['load'] ) ) . '"><code>acf/settings/load_json</code></td>';
-				}
-
-				echo '<td class="qm-num">' . esc_html( (string) $i ) . '</td>';
-				echo '<td>' . QM_Output_Html::output_filename( $this->remove_abspath( $path ), $path ) . '</td>';
-
-				echo '</tr>';
-
-				$i++;
-			}
-		}
-
-		echo '</tbody>';
-		echo '</table>';
-
-		$this->output_local_json_field_groups();
-
-		echo '</div>';
-	}
-
-	protected function output_local_json_field_groups() : void {
-		$data = $this->collector->get_data();
-
-		if ( empty( $data->local_json['groups'] ) ) {
-			echo '<section class="qm-non-tabular"><div class="qm-notice"><p>No local JSON field groups found.</p></div></section>';
-			return;
-		}
-
-		$groups = array();
-
-		foreach ( $data->local_json['groups'] as $group ) {
-			$groups[ $group['title'] ] = $group;
-		}
-
-		ksort( $groups, SORT_NATURAL );
-
-		echo '<table>';
-		echo '<caption><h2>Field Groups</caption>';
-		echo '<thead>';
-		echo '<tr>';
-		echo '<th scope="col">Title</th>';
-		echo '<th scope="col">Key</th>';
-		echo '<th scope="col">File</th>';
-		echo '</tr>';
-		echo '</thead>';
-		echo '<tbody>';
-
-		foreach ( $groups as $group ) {
-			printf(
-				'<tr><th scope="row">%s</th><td>%s</td><td>%s</td></tr>',
-				esc_html( $group['title'] ),
-				esc_html( $group['key'] ),
-				QM_Output_Html::output_filename( $this->remove_abspath( $group['local_file'] ), $group['local_file'] )
-			);
-		}
-
-		echo '</tbody>';
-		printf( '<tfoot><tr><td colspan="3">Total: <span class="qm-items-number">%d</span></td></tr></tfoot>', count( $data->local_json['groups'] ) );
-		echo '</table>';
-	}
-
-	public function remove_abspath( string $path ) : string {
-		return str_replace( ABSPATH, '', $path );
-	}
-
 	/**
 	 * @param array<string, array<string, mixed>> $menu
 	 * @return array<string, array<string, mixed>>
@@ -556,16 +278,16 @@ class QMX_Output_Html_ACF extends QM_Output_Html {
 
 		if ( is_admin() ) {
 			$menu['qm-acf']['children']['loaded_field_groups'] = array(
-				'title' => esc_html__( 'Field Groups', 'query-monitor-extend' ) . sprintf( ' (%d)', count( $data->loaded_field_groups ) ),
-				'href'  => '#qm-acf-loaded_field_groups',
 				'id'    => 'query-monitor-extend-acf-loaded_field_groups',
+				'panel' => 'acf-loaded_field_groups',
+				'title' => esc_html__( 'Field Groups', 'query-monitor-extend' ) . sprintf( ' (%d)', count( $data->loaded_field_groups ) ),
 			);
 		}
 
 		$menu['qm-acf']['children']['local_json'] = array(
-			'title' => esc_html__( 'Local JSON', 'query-monitor-extend' ) . sprintf( ' (%d)', count( $data->local_json['groups'] ) ),
-			'href'  => '#qm-acf-local_json',
 			'id'    => 'query-monitor-extend-acf-local_json',
+			'panel' => 'acf-local_json',
+			'title' => esc_html__( 'Local JSON', 'query-monitor-extend' ) . sprintf( ' (%d)', count( $data->local_json['groups'] ) ),
 		);
 
 		return $menu;
@@ -573,8 +295,21 @@ class QMX_Output_Html_ACF extends QM_Output_Html {
 }
 
 add_filter( 'qm/outputter/html', static function ( array $output ) : array {
-	if ( $collector = QM_Collectors::get( 'acf' ) ) {
-		$output['acf'] = new QMX_Output_Html_ACF( $collector );
+	$collector = QM_Collectors::get( 'acf' );
+
+	if ( ! $collector ) {
+		return $output;
+	}
+
+	$output['acf']                 = new QMX_Output_Html_ACF( $collector );
+	$output['acf-concerned_hooks'] = new QMX_Output_Html_Concerned_Hooks( $collector );
+
+	require_once __DIR__ . '/qmx-acf-output-local-json.php';
+	$output['acf-local_json'] = new QMX_Output_Html_ACF_LocalJSON( $collector );
+
+	if ( is_admin() ) {
+		require_once __DIR__ . '/qmx-acf-output-loaded-field-groups.php';
+		$output['acf-loaded_field_groups'] = new QMX_Output_Html_ACF_LoadedFieldGroups( $collector );
 	}
 
 	return $output;

--- a/acf/qmx-acf-output.php
+++ b/acf/qmx-acf-output.php
@@ -397,23 +397,19 @@ class QMX_Output_Html_ACF extends QM_Output_Html {
 	 */
 	protected function output_column_caller( array $row ) : void {
 		$trace          = $row['trace'];
-		$filtered_trace = $trace->get_display_trace();
+		$filtered_trace = $trace->get_filtered_trace();
 		$caller_name    = self::output_filename( $row['caller']['function'] . '()', $row['caller']['file'], $row['caller']['line'] );
 		$stack          = array();
 
 		array_shift( $filtered_trace );
 
 		foreach ( $filtered_trace as $item ) {
-			$item = wp_parse_args( $item, array(
-				'file' => '',
-				'line' => '',
-			) );
-
-			if ( empty( $item['display'] ) ) {
+			if ( empty( $item->id ) ) {
 				continue;
 			}
 
-			$stack[] = self::output_filename( $item['display'], $item['file'], $item['line'] );
+			$display = $item->id . '(' . ( $item->args ?? '' ) . ')';
+			$stack[] = self::output_filename( $display, (string) $item->file, (int) ( $item->line ?? 0 ) );
 		}
 
 		if ( 1 < count( $stack ) ) {

--- a/heartbeat/qmx-heartbeat-output.php
+++ b/heartbeat/qmx-heartbeat-output.php
@@ -85,7 +85,8 @@ class QMX_Output_Html_Heartbeat extends QM_Output_Html {
 
 add_filter( 'qm/outputter/html', static function ( array $output ) : array {
 	if ( $collector = QM_Collectors::get( 'heartbeat' ) ) {
-		$output['heartbeat'] = new QMX_Output_Html_Heartbeat( $collector );
+		$output['heartbeat']                 = new QMX_Output_Html_Heartbeat( $collector );
+		$output['heartbeat-concerned_hooks'] = new QMX_Output_Html_Concerned_Hooks( $collector );
 	}
 
 	return $output;

--- a/image-sizes/qmx-image-sizes-output.php
+++ b/image-sizes/qmx-image-sizes-output.php
@@ -164,7 +164,8 @@ class QMX_Output_Html_Image_Sizes extends QM_Output_Html {
 
 add_filter( 'qm/outputter/html', static function ( array $output ) : array {
 	if ( $collector = QM_Collectors::get( 'image_sizes' ) ) {
-		$output['image_sizes'] = new QMX_Output_Html_Image_Sizes( $collector );
+		$output['image_sizes']                 = new QMX_Output_Html_Image_Sizes( $collector );
+		$output['image_sizes-concerned_hooks'] = new QMX_Output_Html_Concerned_Hooks( $collector );
 	}
 
 	return $output;

--- a/paths/qmx-paths-output.php
+++ b/paths/qmx-paths-output.php
@@ -108,7 +108,8 @@ class QMX_Output_Html_Paths extends QM_Output_Html {
 
 add_filter( 'qm/outputter/html', static function ( array $output ) : array {
 	if ( $collector = QM_Collectors::get( 'paths' ) ) {
-		$output['paths'] = new QMX_Output_Html_Paths( $collector );
+		$output['paths']                 = new QMX_Output_Html_Paths( $collector );
+		$output['paths-concerned_hooks'] = new QMX_Output_Html_Concerned_Hooks( $collector );
 	}
 
 	return $output;

--- a/qmx-output-html-concerned-hooks.php
+++ b/qmx-output-html-concerned-hooks.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Reusable sub-panel outputter that renders a collector's
+ * concerned actions/filters as a "Hooks in Use" table.
+ *
+ * Mirrors the QM 3.x `output_concerns()` output so React's
+ * PhpPanelFallback picks up a matching `qm-{id}-concerned_hooks-container`
+ * div when the auto-added child menu is clicked.
+ */
+class QMX_Output_Html_Concerned_Hooks extends QM_Output_Html {
+
+	public function name() {
+		return __( 'Hooks in Use', 'query-monitor-extend' );
+	}
+
+	public function output() : void {
+		$concerns = array(
+			'concerned_actions' => __( 'Action', 'query-monitor-extend' ),
+			'concerned_filters' => __( 'Filter', 'query-monitor-extend' ),
+		);
+
+		if (
+			empty( $this->collector->concerned_actions )
+			&& empty( $this->collector->concerned_filters )
+		) {
+			$this->before_non_tabular_output( $this->collector->id() . '-concerned_hooks', $this->name() );
+			echo '<div class="qm-notice"><p>' . esc_html__( 'No concerned hooks recorded.', 'query-monitor-extend' ) . '</p></div>';
+			$this->after_non_tabular_output();
+			return;
+		}
+
+		$id = $this->collector->id() . '-concerned_hooks';
+
+		printf(
+			'<div class="qm qm-concerns" id="%1$s" role="tabpanel" aria-labelledby="%1$s-caption" tabindex="-1">',
+			esc_attr( $id )
+		);
+
+		echo '<table>';
+
+		printf(
+			'<caption><h2 id="%1$s-caption">%2$s</h2></caption>',
+			esc_attr( $id ),
+			esc_html( $this->name() )
+		);
+
+		echo '<thead><tr>';
+		echo '<th scope="col">' . esc_html__( 'Hook', 'query-monitor-extend' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Type', 'query-monitor-extend' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Priority', 'query-monitor-extend' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Callback', 'query-monitor-extend' ) . '</th>';
+		echo '<th scope="col">' . esc_html__( 'Component', 'query-monitor-extend' ) . '</th>';
+		echo '</tr></thead>';
+
+		echo '<tbody>';
+
+		foreach ( array_keys( $concerns ) as $key ) {
+			if ( empty( $this->collector->$key ) ) {
+				continue;
+			}
+
+			# QM 4.x `QM_Hook::process()` no longer populates the `parts`
+			# array that `QM_Output_Html_Hooks::output_hook_table()` reads
+			# for its `data-qm-name` attribute, and closure callbacks leave
+			# `$cb->name` null which fatals in `output_filename()`'s
+			# `strpos()`. Backfill both with the minimum the renderer needs.
+			$hooks = array_map( static function ( array $hook ) : array {
+				$hook['parts'] ??= array();
+
+				foreach ( $hook['actions'] ?? array() as $action ) {
+					$cb = $action['callback'] ?? null;
+
+					if ( is_object( $cb ) && null === $cb->name && 'closure' === $cb->callback_type ) {
+						// `{closure}` triggers output_filename's built-in closure formatter.
+						$cb->name = '{closure}';
+					}
+				}
+
+				return $hook;
+			}, $this->collector->$key );
+
+			QM_Output_Html_Hooks::output_hook_table( $hooks, true );
+		}
+
+		echo '</tbody></table></div>';
+	}
+}

--- a/query-monitor-extend.php
+++ b/query-monitor-extend.php
@@ -108,6 +108,9 @@ if ( trailingslashit( constant( 'WPMU_PLUGIN_DIR' ) ) === $dir ) {
 	$dir .= 'query-monitor-extend/';
 }
 
+# Load the shared concerned-hooks outputter before registration runs.
+require_once $dir . 'qmx-output-html-concerned-hooks.php';
+
 # Include all collector and outputters.
 foreach ( $collector_names as $collector_name ) {
 	$files = array(


### PR DESCRIPTION
## Summary

Query Monitor 4.0 introduced two breaking changes that prevent `query-monitor-extend` from working end-to-end:

1. **Backtrace API changed.** `QM_Backtrace::get_trace()` and `->ignore()` were removed; `get_filtered_trace()` now returns `QM_Data_Stack_Frame` objects instead of associative arrays. This broke the ACF collector on every page load.
2. **Concerned-hooks React panels are gone for third-party collectors.** QM 4.x only registers React panels for its own built-in collectors, and its legacy `output_hook_table()` still expects QM 3.x-shaped data (`parts` array, string callback names). As a result, the "Hooks in Use" sub-panels for `acf`, `paths`, `heartbeat`, and `image_sizes` no longer render.

This PR addresses both.

## Screenshots

<img width="979" height="514" alt="image" src="https://github.com/user-attachments/assets/5f280265-2b0c-4870-b9aa-5ec371621494" />

<img width="1178" height="645" alt="image" src="https://github.com/user-attachments/assets/67c76f71-8e89-43fa-a361-67fa310d4532" />


## Changes

### 1. ACF collector — `QM_Backtrace` migration

- Switch to `get_filtered_trace()` and object property access (`$frame->id`, `$frame->file`, etc.).
- Handle QM 4.x's frame shift: `frame[N]->file` now reports where `frame[N]` made its call (i.e., the original `frame[N-1]->file`), so the caller site is tracked one frame deeper than before.

### 2. Shared concerned-hooks fallback renderer

- New `QMX_Output_Html_Concerned_Hooks` backfills the fields expected by QM's `PhpPanelFallback` so the sub-panels come back under 4.x. Only sets `$cb->name = '{closure}'` when missing — `output_filename()` handles closure formatting natively via its `{closure` prefix detection.
- Wired into the `acf`, `paths`, `heartbeat`, and `image_sizes` collectors.

### 3. Split ACF output into sub-panel classes

- `QMX_Output_Html_ACF_LocalJSON` and `QMX_Output_Html_ACF_LoadedFieldGroups` replace the previously inlined HTML inside `QMX_Output_Html_ACF`, matching QM 4.x's pattern for sub-panels.

## Testing

- Installed on WordPress with QM 4.0.6 and PHP 8.2.
- ACF panel populates without errors on both admin and front-end pages.
- "Hooks in Use" sub-panels render correctly for ACF, Paths, Heartbeat, and Image Sizes.
- Verified on pages with and without ACF in use.

Fixes #91
Fixes #92
Fixes #94



